### PR TITLE
Show alert when on mobile

### DIFF
--- a/apps/govern/components/Layout/index.tsx
+++ b/apps/govern/components/Layout/index.tsx
@@ -37,7 +37,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
         {isMobile && (
           <Alert
             className="mt-16"
-            message="This page is not optimized for mobile. For best experience, please come back on desktop."
+            message="This page is not optimized for mobile. For the best experience, please come back on desktop."
             showIcon
             type="warning"
           />

--- a/apps/govern/components/Layout/index.tsx
+++ b/apps/govern/components/Layout/index.tsx
@@ -1,5 +1,7 @@
-import { Layout as AntdLayout } from 'antd';
+import { Alert, Layout as AntdLayout } from 'antd';
 import { FC, ReactNode } from 'react';
+
+import { useScreen } from 'libs/ui-theme/src';
 
 import { LoginV2 } from 'components/Login';
 
@@ -16,6 +18,8 @@ interface LayoutProps {
 }
 
 export const Layout: FC<LayoutProps> = ({ children }) => {
+  const { isMobile } = useScreen();
+
   return (
     <CustomLayout>
       <OlasHeader>
@@ -30,6 +34,15 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
       </OlasHeader>
 
       <Content className="site-layout">
+        {isMobile && (
+          <Alert
+            className="mt-16"
+            message="This page is not optimized for mobile. For best experience, please come back on desktop."
+            showIcon
+            type="warning"
+          />
+        )}
+
         <div className="site-layout-background">{children}</div>
       </Content>
 

--- a/libs/ui-theme/src/index.ts
+++ b/libs/ui-theme/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/ui-theme';
 export * from './lib/ThemeConfig';
 export * from './lib/GlobalStyles';
+export * from './lib/hooks';

--- a/libs/ui-theme/src/lib/hooks/index.ts
+++ b/libs/ui-theme/src/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useScreen';

--- a/libs/ui-theme/src/lib/hooks/useScreen.ts
+++ b/libs/ui-theme/src/lib/hooks/useScreen.ts
@@ -1,0 +1,12 @@
+import { Grid } from 'antd';
+
+const { useBreakpoint } = Grid;
+
+export const useScreen = () => {
+  const screens = useBreakpoint();
+  const isMobile = (screens.sm || screens.xs) && !screens.md;
+  const isTablet = (screens.md || screens.lg) && !screens.xl;
+  const isDesktop = screens.xl;
+
+  return { isMobile, isTablet, isDesktop, ...screens };
+};


### PR DESCRIPTION
## Proposed changes

1) Moves useScreen hook from `@autonolas/frontend-library` to shared libs
2) Displays alert on mobile screens

![image](https://github.com/valory-xyz/autonolas-frontend-mono/assets/22725775/e5fca29f-49cb-40f1-9436-2a75afa6d4d5)

## Fixes

`isTablet` didn't work correctly in `@autonolas/frontend-library` because it checked `!sm` and `!xs` when they both were true (see at the pic what values are true when on "lg" screen)

<img width="312" alt="Screenshot 2024-06-17 at 11 47 11" src="https://github.com/valory-xyz/autonolas-frontend-mono/assets/22725775/3abc220f-ff03-45d3-89ba-b2e87b04f9f0">


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
