### PR TITLE
Fix outdated hash on details page

### DIFF
--- a/apps/autonolas-registry/components/ListComponents/utils.jsx
+++ b/apps/autonolas-registry/components/ListComponents/utils.jsx
@@ -1,8 +1,7 @@
-import {
-  getMechMinterContract,
-  getComponentContract,
-} from 'common-util/Contracts';
+import { GATEWAY_URL, HASH_PREFIX } from 'libs/util-constants/src';
+
 import { getListByAccount } from 'common-util/ContractUtils/myList';
+import { getComponentContract, getMechMinterContract } from 'common-util/Contracts';
 import { getFirstAndLastIndex } from 'common-util/List/functions';
 import { sendTransaction } from 'common-util/functions';
 
@@ -84,6 +83,15 @@ export const updateComponentHashes = async (account, id, newHash) => {
 
 export const getTokenUri = async (id) => {
   const contract = getComponentContract();
-  const response = await contract.methods.tokenURI(id).call();
-  return response;
+
+  const updatedHashes = await contract.methods.getUpdatedHashes(id).call();
+  const unitHashes = updatedHashes.unitHashes;
+
+  if (unitHashes.length > 0) {
+    // return the last updated hash if there are `updatedHashes`
+    return `${GATEWAY_URL}${unitHashes[unitHashes.length - 1].replace('0x', HASH_PREFIX)}`;
+  } else {
+    // return initial hash if there are no updatedHashes
+    return await contract.methods.tokenURI(id).call();
+  }
 };

--- a/apps/autonolas-registry/components/ListComponents/utils.jsx
+++ b/apps/autonolas-registry/components/ListComponents/utils.jsx
@@ -1,4 +1,4 @@
-import { GATEWAY_URL, HASH_PREFIX } from 'libs/util-constants/src';
+import { GATEWAY_URL, HASH_PREFIX } from 'libs/util-constants/src/lib/ipfs';
 
 import { getListByAccount } from 'common-util/ContractUtils/myList';
 import { getComponentContract, getMechMinterContract } from 'common-util/Contracts';

--- a/apps/autonolas-registry/jest.config.js
+++ b/apps/autonolas-registry/jest.config.js
@@ -19,11 +19,13 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', {
-      presets: ['@nx/next/babel'],
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        presets: ['@nx/next/babel'],
         tsconfig: '<rootDir>/tsconfig.spec.json',
         useESM: true,
-      }
+      },
     ],
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
   },


### PR DESCRIPTION
## Fixes
Context: We display the metadata hash on listing pages and detail pages, but we get them from different sources: for listing pages - from the registry subgraph, for detail pages - from the contract state. One user after updating their metadata hash found that it wasn't updated on the detail page.

Fix: check if there are updated hashes and get the last one, otherwise get the initial one.
https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/UnitRegistry.sol#L171

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
