### PR TITLE
fix: load contracts of different chain

### DIFF
--- a/apps/launch/components/Login/LoginV2.tsx
+++ b/apps/launch/components/Login/LoginV2.tsx
@@ -64,7 +64,6 @@ export const LoginV2 = () => {
     return walletConnectedChain?.id !== networkId;
   }, [walletConnectedChain, networkId]);
 
-  // TODO: figure out how to fix "SwitchChainNotSupportedError"
   const onSwitchNetwork = useCallback(async () => {
     if (!networkId) return;
 

--- a/apps/launch/hooks/useGetMyStakingContracts.ts
+++ b/apps/launch/hooks/useGetMyStakingContracts.ts
@@ -150,9 +150,7 @@ export const useGetMyStakingContracts = () => {
   const instanceAddresses = useGetInstanceAddresses();
   const myStakingContractsMetadata = useGetMyStakingContractsMetadata(instanceAddresses);
   const nominees = useGetAllNominees();
-  const { myStakingContracts, isMyStakingContractsLoading } = useAppSelector(
-    (state) => state.launch,
-  );
+  const { myStakingContracts } = useAppSelector((state) => state.launch);
 
   const { networkId } = useAppSelector((state) => state.network);
 
@@ -194,6 +192,5 @@ export const useGetMyStakingContracts = () => {
     myStakingContractsMetadata,
     myStakingContracts,
     networkId,
-    isMyStakingContractsLoading,
   ]);
 };


### PR DESCRIPTION
## Proposed changes

<img width="1508" alt="Screenshot2" src="https://github.com/valory-xyz/autonolas-frontend-mono/assets/22061815/292c5464-386b-4036-a6c0-b6146c1c7b28">

- My staking contracts should load on different chains. For example, if the wallet is connected to Ethereum, then `/polygon/my-staking-contract` should load as expected.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
