### PR TITLE
(launch) fix: add remaining fields to staking contract form

### DIFF
--- a/apps/launch/common-util/constants/stakingContract.ts
+++ b/apps/launch/common-util/constants/stakingContract.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { Address } from 'viem';
 import { arbitrum, base, celo, gnosis, mainnet, optimism, polygon } from 'viem/chains';
 
@@ -11,9 +10,9 @@ export const CONTRACT_TEMPLATES = [
   },
 ];
 
-export const CONTRACT_COMMON_VALUES = {
+export const CONTRACT_DEFAULT_VALUES = {
   // Minimum service staking deposit value required for staking
-  minStakingDeposit: ethers.parseUnits('10', 18),
+  minStakingDeposit: 10,
   // Min number of staking periods before the service can be unstaked
   minNumStakingPeriods: 3,
   // Max number of accumulated inactivity periods after which the service is evicted
@@ -24,8 +23,6 @@ export const CONTRACT_COMMON_VALUES = {
   timeForEmissions: 2592000, // 30 days
   // Number of agent instances in the service
   numAgentInstances: 1,
-  // Optional agent Ids requirement
-  agentIds: [14],
   // Optional service multisig threshold requirement
   threshold: 0,
   // Optional service configuration hash requirement
@@ -55,17 +52,6 @@ export const IMPLEMENTATION_ADDRESSES: Addresses = {
   [base.id]: '0xEB5638eefE289691EcE01943f768EDBF96258a80',
   [arbitrum.id]: '0x04b0007b2aFb398015B76e5f22993a1fddF83644',
   [celo.id]: '0xe1E1B286EbE95b39F785d8069f2248ae9C41b7a9',
-};
-
-// TODO: update addresses when real contracts are deployed
-export const ACTIVITY_CHECKER_ADDRESSES: Addresses = {
-  [mainnet.id]: '0x0Dc23eEf3bC64CF3cbd8f9329B57AE4C4f28d5d2' as Address,
-  [optimism.id]: '' as Address,
-  [gnosis.id]: '' as Address,
-  [polygon.id]: '' as Address,
-  [base.id]: '' as Address,
-  [arbitrum.id]: '' as Address,
-  [celo.id]: '' as Address,
 };
 
 export const SERVICE_REGISTRY_ADDRESSES: Addresses = {

--- a/apps/launch/common-util/functions/stakingContract.ts
+++ b/apps/launch/common-util/functions/stakingContract.ts
@@ -6,8 +6,7 @@ import { HASH_PREFIX } from 'libs/util-constants/src';
 import { STAKING_TOKEN } from 'libs/util-contracts/src/lib/abiAndAddresses';
 
 import {
-  ACTIVITY_CHECKER_ADDRESSES,
-  CONTRACT_COMMON_VALUES,
+  CONTRACT_DEFAULT_VALUES,
   ChainId,
   SERVICE_REGISTRY_ADDRESSES,
   SERVICE_REGISTRY_TOKEN_UTILITY_ADDRESSES,
@@ -18,21 +17,50 @@ type StakingContractValues = {
   metadataHash: string;
   maxNumServices: number;
   rewardsPerSecond: number;
+  minStakingDeposit: number;
+  minNumStakingPeriods: number;
+  maxNumInactivityPeriods: number;
+  livenessPeriod: number;
+  timeForEmissions: number;
+  numAgentInstances: number;
+  agentIds: string;
+  threshold: number;
+  configHash: string;
+  activityChecker: string;
   chainId: ChainId;
 };
 export const getStakingContractInitPayload = ({
   metadataHash,
   maxNumServices,
   rewardsPerSecond,
+  minStakingDeposit,
+  minNumStakingPeriods,
+  maxNumInactivityPeriods,
+  livenessPeriod,
+  timeForEmissions,
+  numAgentInstances,
+  agentIds,
+  threshold,
+  configHash,
+  activityChecker,
   chainId,
 }: StakingContractValues) => {
   const stakingParams = {
     metadataHash,
     maxNumServices,
-    rewardsPerSecond: ethers.parseUnits(`${rewardsPerSecond}`, 18),
-    ...CONTRACT_COMMON_VALUES,
+    rewardsPerSecond: `${rewardsPerSecond * 10 ** 18}`,
+    minStakingDeposit: `${minStakingDeposit * 10 ** 18}`,
+    minNumStakingPeriods,
+    maxNumInactivityPeriods,
+    livenessPeriod,
+    timeForEmissions,
+    numAgentInstances,
+    agentIds: agentIds.split(/,\s?/).map((agentId) => Number(agentId)),
+    threshold,
+    configHash,
+    activityChecker,
+    proxyHash: CONTRACT_DEFAULT_VALUES.proxyHash,
     serviceRegistry: SERVICE_REGISTRY_ADDRESSES[chainId],
-    activityChecker: ACTIVITY_CHECKER_ADDRESSES[chainId],
   };
 
   const contractInterface = new ethers.Interface(STAKING_TOKEN.abi);

--- a/apps/launch/components/MyStakingContracts/Create/index.tsx
+++ b/apps/launch/components/MyStakingContracts/Create/index.tsx
@@ -23,6 +23,7 @@ import { notifyWarning } from 'libs/util-functions/src';
 
 import { ErrorAlert } from 'common-util/ErrorAlert';
 import {
+  CONTRACT_DEFAULT_VALUES,
   CONTRACT_TEMPLATES,
   IMPLEMENTATION_ADDRESSES,
   isSupportedChainId,
@@ -37,16 +38,14 @@ import { ErrorType } from 'types/index';
 
 import { Hint, StyledMain, Title } from './styles';
 import {
-  DESCRIPTION_FIELD_RULES,
   FormValues,
-  MAX_NUM_SERVICES_FIELD_RULES,
+  LABELS,
   MaxNumServicesLabel,
-  NAME_FIELD_RULES,
-  REWARDS_PER_SECOND_FIELD_RULES,
   RewardsPerSecondLabel,
   TextWithTooltip,
   WrongNetworkAlert,
   checkImplementationVerified,
+  getFieldRules,
 } from './utils';
 
 const { Text } = Typography;
@@ -88,7 +87,22 @@ export const CreateStakingContract = () => {
     setError(null);
     setIsLoading(true);
 
-    const { name, description, maxNumServices, rewardsPerSecond } = values;
+    const {
+      name,
+      description,
+      maxNumServices,
+      rewardsPerSecond,
+      minStakingDeposit,
+      minNumStakingPeriods,
+      maxNumInactivityPeriods,
+      livenessPeriod,
+      timeForEmissions,
+      numAgentInstances,
+      agentIds,
+      threshold,
+      configHash,
+      activityChecker,
+    } = values;
 
     try {
       const metadataHash = await getIpfsHash({ name, description });
@@ -97,6 +111,16 @@ export const CreateStakingContract = () => {
         metadataHash,
         maxNumServices,
         rewardsPerSecond,
+        minStakingDeposit,
+        minNumStakingPeriods,
+        maxNumInactivityPeriods,
+        livenessPeriod,
+        timeForEmissions,
+        numAgentInstances,
+        agentIds,
+        threshold,
+        configHash,
+        activityChecker,
         chainId: chain.id,
       });
 
@@ -148,20 +172,25 @@ export const CreateStakingContract = () => {
 
         {alertMessage}
 
-        <Form layout="vertical" onFinish={handleCreate} requiredMark={false}>
+        <Form
+          layout="vertical"
+          onFinish={handleCreate}
+          requiredMark={false}
+          initialValues={{ ...CONTRACT_DEFAULT_VALUES }}
+        >
           <Form.Item
-            label={<Text type="secondary">Name</Text>}
+            label={<Text type="secondary">{LABELS.name}</Text>}
             name="name"
-            rules={NAME_FIELD_RULES}
+            rules={getFieldRules(LABELS.name)}
           >
             <Input />
           </Form.Item>
 
           <Form.Item
-            label={<Text type="secondary">Description</Text>}
+            label={<Text type="secondary">{LABELS.description}</Text>}
             name="description"
             className="mb-0"
-            rules={DESCRIPTION_FIELD_RULES}
+            rules={getFieldRules(LABELS.description)}
           >
             <Input.TextArea rows={4} />
           </Form.Item>
@@ -195,7 +224,7 @@ export const CreateStakingContract = () => {
               <Form.Item
                 label={<MaxNumServicesLabel />}
                 name="maxNumServices"
-                rules={MAX_NUM_SERVICES_FIELD_RULES}
+                rules={getFieldRules(LABELS.maxNumServices)}
               >
                 <InputNumber placeholder="e.g. 100" step="1" style={INPUT_WIDTH_STYLE} />
               </Form.Item>
@@ -204,12 +233,94 @@ export const CreateStakingContract = () => {
               <Form.Item
                 label={<RewardsPerSecondLabel />}
                 name="rewardsPerSecond"
-                rules={REWARDS_PER_SECOND_FIELD_RULES}
+                rules={getFieldRules(LABELS.rewardsPerSecond)}
               >
                 <InputNumber placeholder="e.g. 0.0003" step="0.0001" style={INPUT_WIDTH_STYLE} />
               </Form.Item>
             </Col>
           </Row>
+          <Row gutter={24}>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.minStakingDeposit}</Text>}
+                name="minStakingDeposit"
+                rules={getFieldRules(LABELS.minStakingDeposit)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.minNumStakingPeriods}</Text>}
+                name="minNumStakingPeriods"
+                rules={getFieldRules(LABELS.minNumStakingPeriods)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.maxNumInactivityPeriods}</Text>}
+                name="maxNumInactivityPeriods"
+                rules={getFieldRules(LABELS.maxNumInactivityPeriods)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.livenessPeriod}</Text>}
+                name="livenessPeriod"
+                rules={getFieldRules(LABELS.livenessPeriod)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.timeForEmissions}</Text>}
+                name="timeForEmissions"
+                rules={getFieldRules(LABELS.timeForEmissions)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item
+                label={<Text type="secondary">{LABELS.numAgentInstances}</Text>}
+                name="numAgentInstances"
+                rules={getFieldRules(LABELS.numAgentInstances)}
+              >
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col span={12}>
+              <Form.Item label={<Text type="secondary">{LABELS.agentIds}</Text>} name="agentIds">
+                <Input style={INPUT_WIDTH_STYLE} placeholder="14,25" />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label={<Text type="secondary">{LABELS.threshold}</Text>} name="threshold">
+                <InputNumber step="1" style={INPUT_WIDTH_STYLE} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Form.Item label={<Text type="secondary">{LABELS.configHash}</Text>} name="configHash">
+            <Input />
+          </Form.Item>
+          <Form.Item
+            label={<Text type="secondary">{LABELS.activityChecker}</Text>}
+            name="activityChecker"
+            rules={getFieldRules(LABELS.activityChecker)}
+          >
+            <Input />
+          </Form.Item>
           <Flex justify="end" gap={12}>
             <Link href={`/${networkName}/${URL.myStakingContracts}`} passHref>
               <Button size="large">Cancel</Button>

--- a/apps/launch/components/MyStakingContracts/Create/utils.tsx
+++ b/apps/launch/components/MyStakingContracts/Create/utils.tsx
@@ -18,6 +18,33 @@ export type FormValues = {
   description: string;
   maxNumServices: number;
   rewardsPerSecond: number;
+  minStakingDeposit: number;
+  minNumStakingPeriods: number;
+  maxNumInactivityPeriods: number;
+  livenessPeriod: number;
+  timeForEmissions: number;
+  numAgentInstances: number;
+  agentIds: string;
+  threshold: number;
+  configHash: string;
+  activityChecker: string;
+};
+
+export const LABELS = {
+  name: 'Name',
+  description: 'Description',
+  maxNumServices: 'Maximum number of staked agents',
+  rewardsPerSecond: 'Rewards, OLAS per second',
+  minStakingDeposit: 'Minimum service staking deposit, OLAS',
+  minNumStakingPeriods: 'Minimum number of staking periods',
+  maxNumInactivityPeriods: 'Minimum number of accumulated inactivity periods',
+  livenessPeriod: 'Liveness period',
+  timeForEmissions: 'Time for emissions',
+  numAgentInstances: 'Number of agent instances',
+  agentIds: 'Agent Ids',
+  threshold: 'Multisig threshold',
+  configHash: 'Service configuration hash',
+  activityChecker: 'Activity checker address',
 };
 
 export const TextWithTooltip = ({
@@ -36,7 +63,7 @@ export const TextWithTooltip = ({
 
 export const MaxNumServicesLabel = () => (
   <TextWithTooltip
-    text="Maximum number of staked agents"
+    text={LABELS.maxNumServices}
     description={
       <>
         How many agents do you need running? Agents can be sovereign or decentralized agents. They
@@ -52,7 +79,7 @@ export const MaxNumServicesLabel = () => (
 
 export const RewardsPerSecondLabel = () => (
   <TextWithTooltip
-    text="Rewards, OLAS per second"
+    text={LABELS.rewardsPerSecond}
     description="Token rewards come from the Olas protocol"
   />
 );
@@ -94,11 +121,6 @@ export const checkImplementationVerified = async (chainId: number, implementatio
   return result;
 };
 
-export const NAME_FIELD_RULES = [{ required: true, message: 'Please enter Name' }];
-export const DESCRIPTION_FIELD_RULES = [{ required: true, message: 'Please enter Description' }];
-export const MAX_NUM_SERVICES_FIELD_RULES = [
-  { required: true, message: 'Please enter Maximum number of staked agents' },
-];
-export const REWARDS_PER_SECOND_FIELD_RULES = [
-  { required: true, message: 'Please enter Rewards per second' },
+export const getFieldRules = (label: string) => [
+  { required: true, message: `Please enter ${label}` },
 ];


### PR DESCRIPTION
## Fixes

Added remaining fields to the staking contract form, filled with default values
Note: we agreed to add it quickly for convenience, we'll provide better labels/tooltips/validations later

<img width="907" alt="image" src="https://github.com/user-attachments/assets/29b79b45-cc90-42d4-8e85-5f56f50e37bb">


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
