### PR TITLE
(registry) fix: rewards not loading

### DIFF
--- a/libs/common-contract-functions/src/lib/useRewards.ts
+++ b/libs/common-contract-functions/src/lib/useRewards.ts
@@ -26,7 +26,7 @@ export const useClaimableIncentives = (
     chainId: mainnet.id,
     args: [ownerAddress, [BigInt(tokenomicsUnitType || '0')], [BigInt(id)]],
     query: {
-      enabled: !!ownerAddress && !!id && isNumber(tokenomicsUnitType),
+      enabled: !!ownerAddress && !!id && tokenomicsUnitType !== undefined,
       select: (data) => {
         const [reward, topup] = data as [bigint, bigint];
         return {


### PR DESCRIPTION
## Fixes

Rewards on registry stopped loading due to incorrect type checks
<img width="507" alt="image" src="https://github.com/user-attachments/assets/cbfda58c-81c7-4c6a-b8e5-d4304b889508">

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
