### PR TITLE
(bond) fix: bonding products not working when balancer fails

### DIFF
--- a/apps/bond/components/BondingProducts/Bonding/BondingList/BondingList.jsx
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/BondingList.jsx
@@ -240,8 +240,7 @@ const sortProducts = (list) =>
     // - the API returns zero (shouldn't happen) OR
     // - has error OR
     // - not fetched yet
-    const isSvm = a.lpChainId === VM_TYPE.SVM || b.lpChainId === VM_TYPE.SVM;
-    if (isSvm && isCurrentPriceLpZero(a.fullCurrentPriceLp)) return 1;
+    if (isCurrentPriceLpZero(a.fullCurrentPriceLp)) return 1;
 
     if (isNaN(a.projectedChange)) return 1;
     if (isNaN(b.projectedChange)) return -1;


### PR DESCRIPTION
## Fixes

When balancer url throws error, instead of breaking the whole page return zero price and place broken products in the end of the list

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/803bf8ff-dd5a-4076-a68b-08dbc80cfdcf">

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
