### PR TITLE
(registry) fix: add gas estimation to creating agent and component

### DIFF
--- a/apps/autonolas-registry/components/ListAgents/mint.jsx
+++ b/apps/autonolas-registry/components/ListAgents/mint.jsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router';
 import { Typography } from 'antd';
 import { notifyError, notifySuccess } from '@autonolas/frontend-library';
 
+import { getEstimatedGasLimit } from 'libs/util-functions/src';
+
 import RegisterForm from 'common-util/List/RegisterForm';
 import { AlertSuccess, AlertError } from 'common-util/List/ListCommon';
 import { getMechMinterContract } from 'common-util/Contracts';
@@ -41,14 +43,14 @@ const MintAgent = () => {
 
       const contract = getMechMinterContract(account);
 
-      const fn = contract.methods
-        .create(
-          '1',
-          values.owner_address,
-          `0x${values.hash}`,
-          values.dependencies ? values.dependencies.split(', ') : [],
-        )
-        .send({ from: account });
+      const createFn = contract.methods.create(
+        '1',
+        values.owner_address,
+        `0x${values.hash}`,
+        values.dependencies ? values.dependencies.split(', ') : [],
+      );
+      const estimatedGas = await getEstimatedGasLimit(createFn, account);
+      const fn = createFn.send({ from: account, gasLimit: estimatedGas });
 
       sendTransaction(fn, account)
         .then((result) => {

--- a/apps/autonolas-registry/components/ListComponents/mint.jsx
+++ b/apps/autonolas-registry/components/ListComponents/mint.jsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router';
 import { Typography } from 'antd';
 import { notifyError, notifySuccess } from '@autonolas/frontend-library';
 
+import { getEstimatedGasLimit } from 'libs/util-functions/src';
+
 import RegisterForm from 'common-util/List/RegisterForm';
 import { AlertSuccess, AlertError } from 'common-util/List/ListCommon';
 import { getMechMinterContract } from 'common-util/Contracts';
@@ -40,14 +42,14 @@ const MintComponent = () => {
       }
 
       const contract = getMechMinterContract();
-      const fn = contract.methods
-        .create(
-          '0',
-          values.owner_address,
-          `0x${values.hash}`,
-          values.dependencies ? values.dependencies.split(', ') : [],
-        )
-        .send({ from: account });
+      const createFn = contract.methods.create(
+        '0',
+        values.owner_address,
+        `0x${values.hash}`,
+        values.dependencies ? values.dependencies.split(', ') : [],
+      );
+      const estimatedGas = await getEstimatedGasLimit(createFn, account);
+      const fn = createFn.send({ from: account, gasLimit: estimatedGas });
 
       sendTransaction(fn, account)
         .then((result) => {


### PR DESCRIPTION
## Fixes

Sometimes minting agent or component shows too big gas amount. Added gas estimation
<img width="1792" alt="Screenshot 2024-10-01 at 18 36 25" src="https://github.com/user-attachments/assets/331c435f-c4dc-4a82-87f0-5edb632d3869">


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
