### PR TITLE
(launch) fix: Rewards per second

### DIFF
--- a/apps/launch/components/MyStakingContracts/Create/index.tsx
+++ b/apps/launch/components/MyStakingContracts/Create/index.tsx
@@ -19,7 +19,7 @@ import { mainnet } from 'viem/chains';
 import { useAccount } from 'wagmi';
 
 import { CHAIN_NAMES, EXPLORER_URLS, UNICODE_SYMBOLS } from 'libs/util-constants/src';
-import { notifyWarning } from 'libs/util-functions/src';
+import { allowOnlyNumbers, notifyWarning } from 'libs/util-functions/src';
 
 import { ErrorAlert } from 'common-util/ErrorAlert';
 import {
@@ -145,7 +145,10 @@ export const CreateStakingContract = () => {
     } = values;
 
     try {
-      const metadataHash = await getIpfsHash({ name: contractName, description });
+      const metadataHash = await getIpfsHash({
+        name: contractName,
+        description,
+      });
 
       const implementation = STAKING_TOKEN_ADDRESSES[chain.id];
       const initPayload = getStakingContractInitPayload({
@@ -170,7 +173,11 @@ export const CreateStakingContract = () => {
         throw new Error('Validation failed');
       }
 
-      const result = await createStakingContract({ implementation, initPayload, account });
+      const result = await createStakingContract({
+        implementation,
+        initPayload,
+        account,
+      });
       if (result) {
         const eventLog = result.events?.InstanceCreated?.returnValues;
 
@@ -254,7 +261,11 @@ export const CreateStakingContract = () => {
                 name="rewardsPerSecond"
                 rules={rulesConfig.rewardsPerSecond.rules}
               >
-                <Input placeholder="e.g. 0.000001649305555557" style={INPUT_WIDTH_STYLE} />
+                <Input
+                  placeholder="e.g. 0.000001649305555557"
+                  style={INPUT_WIDTH_STYLE}
+                  onKeyDown={allowOnlyNumbers}
+                />
               </Form.Item>
             </Col>
           </Row>

--- a/libs/util-functions/src/lib/formValidations.ts
+++ b/libs/util-functions/src/lib/formValidations.ts
@@ -37,3 +37,33 @@ export const FORM_VALIDATION: {
     },
   },
 };
+
+export const allowOnlyNumbers = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const isCopy = (e.ctrlKey || e.metaKey) && e.key === 'c';
+  const isPaste = (e.ctrlKey || e.metaKey) && e.key === 'v';
+  const isCut = (e.ctrlKey || e.metaKey) && e.key === 'x';
+  const isSelectAll = (e.ctrlKey || e.metaKey) && e.key === 'a';
+
+  if (
+    !/[0-9]/.test(e.key) &&
+    e.key !== 'Backspace' &&
+    e.key !== 'Delete' &&
+    e.key !== 'ArrowLeft' &&
+    e.key !== 'ArrowRight' &&
+    e.key !== 'Tab' &&
+    e.key !== 'Control' &&
+    e.key !== '.' &&
+    !isCopy &&
+    !isPaste &&
+    !isCut &&
+    !isSelectAll
+  ) {
+    e.preventDefault();
+  }
+
+  // Prevent more than one decimal point
+  const value = e.currentTarget.value;
+  if (e.key === '.' && value.includes('.')) {
+    e.preventDefault();
+  }
+};


### PR DESCRIPTION
## Proposed changes

The “Rewards per second” field was having issues with large decimal numbers, so changed it from “InputNumber” to “Input” to accommodate all values. This also includes validation to ensure only numbers are accepted and only one decimal place is allowed.

## Fixes

<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
