### PR TITLE
(govern) chore: improve votes accuracy, hide epoch section

### DIFF
--- a/apps/govern/components/Contracts/ContractsList.spec.tsx
+++ b/apps/govern/components/Contracts/ContractsList.spec.tsx
@@ -88,12 +88,12 @@ describe('<ContractsList />', () => {
     expect(screen.getByText(/Ethereum/)).toBeInTheDocument();
 
     // current weight column
-    expect(screen.getByText(/10.12%/)).toBeInTheDocument();
-    expect(screen.getByText(/298.89K veOLAS/)).toBeInTheDocument();
+    expect(screen.getByText(/10.123%/)).toBeInTheDocument();
+    expect(screen.getByText(/298.892K veOLAS/)).toBeInTheDocument();
 
     // next weight column
-    expect(screen.getByText(/25.56%/)).toBeInTheDocument();
-    expect(screen.getByText(/297.43K veOLAS/)).toBeInTheDocument();
+    expect(screen.getByText(/25.556%/)).toBeInTheDocument();
+    expect(screen.getByText(/297.434K veOLAS/)).toBeInTheDocument();
   });
 
   describe('Already voted', () => {

--- a/apps/govern/components/Contracts/ContractsList.tsx
+++ b/apps/govern/components/Contracts/ContractsList.tsx
@@ -58,9 +58,13 @@ const getColumns = ({
       dataIndex: 'currentWeight',
       render: (currentWeight) => (
         <Space size={2} direction="vertical">
-          <Text>{`${currentWeight?.percentage.toFixed(2)}%`}</Text>
+          <Text>{`${formatWeiNumber({
+            value: currentWeight?.percentage,
+            maximumFractionDigits: 3,
+          })}%`}</Text>
           <Text type="secondary">{`${formatWeiNumber({
             value: currentWeight?.value,
+            maximumFractionDigits: 3,
           })} veOLAS`}</Text>
         </Space>
       ),
@@ -71,8 +75,14 @@ const getColumns = ({
       dataIndex: 'nextWeight',
       render: (nextWeight) => (
         <Space size={2} direction="vertical">
-          <Text>{`${nextWeight?.percentage.toFixed(2)}%`}</Text>
-          <Text type="secondary">{`${formatWeiNumber({ value: nextWeight?.value })} veOLAS`}</Text>
+          <Text>{`${formatWeiNumber({
+            value: nextWeight?.percentage,
+            maximumFractionDigits: 3,
+          })}%`}</Text>
+          <Text type="secondary">{`${formatWeiNumber({
+            value: nextWeight?.value,
+            maximumFractionDigits: 3,
+          })} veOLAS`}</Text>
         </Space>
       ),
     },

--- a/apps/govern/components/Donate/index.tsx
+++ b/apps/govern/components/Donate/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Alert, Button, Card, Skeleton, Typography } from 'antd';
 import { ethers } from 'ethers';
 import isNumber from 'lodash/isNumber';
@@ -169,7 +170,7 @@ export const DonatePage = () => {
         <DonateForm isLoading={isDonationLoading} onSubmit={onDepositServiceDonationSubmit} />
       </Card>
 
-      <Card className="last-epoch-section">
+      {/* <Card className="last-epoch-section">
         <Title level={2} className="mt-0">
           Epoch Status
         </Title>
@@ -197,7 +198,7 @@ export const DonatePage = () => {
           </Button>
           <Text type="secondary">New epochs must be manually triggered by community members</Text>
         </EpochCheckpointRow>
-      </Card>
+      </Card> */}
     </DonateContainer>
   );
 };


### PR DESCRIPTION
## Proposed changes

1) Temporarily hide epoch section

2) Change the display of weights in the table on the right-hand side to show three decimal places wherever percentages and weights are shown

### weights
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/4bafbd16-dcd4-4e74-9b29-a60544e786ee">
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/2c9645c5-dc97-4e00-9acd-39e6dc2f6c8b">



## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
