### PR TITLE
(registry) fix: remove deprecated networks from dropdown

### DIFF
--- a/apps/autonolas-registry/common-util/Login/config.tsx
+++ b/apps/autonolas-registry/common-util/Login/config.tsx
@@ -11,12 +11,10 @@ import {
   celoAlfajores,
   gnosis,
   gnosisChiado,
-  goerli,
   mainnet,
   optimism,
   optimismSepolia,
   polygon,
-  polygonMumbai,
   mode,
 } from 'wagmi/chains';
 
@@ -25,11 +23,9 @@ import { SOLANA_CHAIN_NAMES, VM_TYPE } from 'util/constants';
 
 export const SUPPORTED_CHAINS: Chain[] = [
   mainnet,
-  goerli,
   gnosis,
   gnosisChiado,
   polygon,
-  polygonMumbai,
   arbitrum,
   arbitrumSepolia,
   base,
@@ -154,9 +150,7 @@ export const ALL_SUPPORTED_CHAINS = [...EVM_SUPPORTED_CHAINS, ...SVM_SUPPORTED_C
       'Optimism',
       'Celo',
       'Mode Mainnet',
-      'Goerli',
       'Gnosis Chiado',
-      'Polygon Mumbai',
       'Solana Devnet',
       'Arbitrum Sepolia',
       'Base Sepolia',


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Remove deprecated networks ("Goerli" and "Polygon Mumbai") as per [this](https://valory-workspace.slack.com/archives/C046RGKM3AL/p1753375219494529) thread.

## Fixes

<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
<img width="941" height="587" alt="Screenshot 2025-07-25 at 5 03 46 PM" src="https://github.com/user-attachments/assets/2a4c2a24-d0db-4377-a3fa-476324e4e44c" />

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
