### PR TITLE
chore: redirect homepage to hire

### DIFF
--- a/apps/build/next.config.js
+++ b/apps/build/next.config.js
@@ -20,7 +20,7 @@ const nextConfig = {
   redirects: async () => [
     {
       source: '/',
-      destination: '/dev-incentives',
+      destination: '/hire',
       permanent: false,
     },
   ],


### PR DESCRIPTION
## Proposed changes

Build homepage redirects to /hire instead of /dev-incentives.
