### PR TITLE
feat: add AI guide API routes for build, hire, and monetize pages   

### DIFF
--- a/apps/build/components/BuildAnAgent/data.json
+++ b/apps/build/components/BuildAnAgent/data.json
@@ -1,0 +1,15 @@
+{
+  "title": "Build an Agent",
+  "resources": [
+    {
+      "label": "Build with Olas' own agent framework",
+      "linkText": "Open Autonomy",
+      "link": "https://stack.olas.network/open-autonomy"
+    },
+    {
+      "label": "Build with other agent frameworks",
+      "linkText": "Olas SDK",
+      "link": "https://stack.olas.network/olas-sdk"
+    }
+  ]
+}

--- a/apps/build/components/BuildAnAgent/index.tsx
+++ b/apps/build/components/BuildAnAgent/index.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 import { COLOR } from 'libs/ui-theme/src';
 
+import data from './data.json';
+
 const { Text } = Typography;
 
 const CONTENT_MAX_WIDTH = 720;
@@ -35,23 +37,10 @@ const DocsCard = styled(Card)`
   }
 `;
 
-const resources = [
-  {
-    label: "Build with Olas' own agent framework",
-    linkText: 'Open Autonomy',
-    link: 'https://stack.olas.network/open-autonomy',
-  },
-  {
-    label: 'Build with other agent frameworks',
-    linkText: 'Olas SDK',
-    link: 'https://stack.olas.network/olas-sdk',
-  },
-];
-
 export const BuildAnAgent = () => (
   <BuildContainer>
     <Row gutter={[16, 16]}>
-      {resources.map((item, index) => (
+      {data.resources.map((item, index) => (
         <Col key={index} span={12} xs={24} sm={24} md={12}>
           <DocsCard>
             <Text className="mb-4" style={{ fontWeight: 500 }}>

--- a/apps/build/components/HireAnAgent/data.json
+++ b/apps/build/components/HireAnAgent/data.json
@@ -1,0 +1,31 @@
+{
+  "title": "Hire an Agent on Olas Marketplace",
+  "prerequisites": ["Python >=3.10 && <3.12", "Poetry >=1.4.0 && <2.x"],
+  "quickstartIntro": "Get started with hiring an agent in three easy steps:",
+  "quickstartItems": [
+    {
+      "title": "1. Install Marketplace Client",
+      "codeBlocks": [
+        "poetry new my_prj --python \">=3.10,<3.12\" && cd my_prj",
+        "poetry add mech-client"
+      ]
+    },
+    {
+      "title": "2. Configure Your Client",
+      "codeBlocks": [
+        "echo MECHX_CHAIN_RPC='https://rpc.eu-central-2.gateway.fm/v4/gnosis/non-archival/mainnet' >> .env"
+      ],
+      "afterNote": "Optional: For improved reliability, update .env with your custom RPC endpoint.",
+      "afterCodeBlocks": ["source .env"]
+    },
+    {
+      "title": "3. Hire On-chain Agent",
+      "codeBlocks": [
+        "poetry run mechx setup --chain-config gnosis",
+        "poetry run mechx request --prompts \"Estimate the chance that Ethereum volatility exceeds 50,000 by the end of 2030\" --priority-mech 0xb3c6319962484602b00d5587e965946890b82101 --tools superforcaster --chain-config gnosis"
+      ]
+    }
+  ],
+  "alertText": "This quickstart covers the basics. For full details and advanced options, see the Olas Stack Documentation.",
+  "docsLink": "/mech-client/"
+}

--- a/apps/build/components/HireAnAgent/data.json
+++ b/apps/build/components/HireAnAgent/data.json
@@ -1,12 +1,12 @@
 {
   "title": "Hire an Agent on Olas Marketplace",
-  "prerequisites": ["Python >=3.10 && <3.14", "Poetry >=1.4.0 && <2.x"],
+  "prerequisites": ["Python >=3.10 && <3.15", "Poetry >=1.4.0 && <2.x"],
   "quickstartIntro": "Get started with hiring an agent in three easy steps:",
   "quickstartItems": [
     {
       "title": "1. Install Marketplace Client",
       "codeBlocks": [
-        "poetry new my_prj --python \">=3.10,<3.14\" && cd my_prj",
+        "poetry new my_prj --python \">=3.10,<3.15\" && cd my_prj",
         "poetry add mech-client"
       ]
     },

--- a/apps/build/components/HireAnAgent/data.json
+++ b/apps/build/components/HireAnAgent/data.json
@@ -1,12 +1,12 @@
 {
   "title": "Hire an Agent on Olas Marketplace",
-  "prerequisites": ["Python >=3.10 && <3.12", "Poetry >=1.4.0 && <2.x"],
+  "prerequisites": ["Python >=3.10 && <3.14", "Poetry >=1.4.0 && <2.x"],
   "quickstartIntro": "Get started with hiring an agent in three easy steps:",
   "quickstartItems": [
     {
       "title": "1. Install Marketplace Client",
       "codeBlocks": [
-        "poetry new my_prj --python \">=3.10,<3.12\" && cd my_prj",
+        "poetry new my_prj --python \">=3.10,<3.14\" && cd my_prj",
         "poetry add mech-client"
       ]
     },

--- a/apps/build/components/HireAnAgent/index.tsx
+++ b/apps/build/components/HireAnAgent/index.tsx
@@ -4,6 +4,8 @@ import { STACK_URL } from 'libs/util-constants/src';
 import styled from 'styled-components';
 import { PageWrapper } from 'util/theme';
 
+import data from './data.json';
+
 const { Title, Text, Paragraph } = Typography;
 
 const HireContainer = styled.div`
@@ -18,50 +20,20 @@ const HireContainer = styled.div`
 const Prerequisites = () => (
   <div>
     <Title level={4}>Prerequisites</Title>
-    <CodeBlock>Python &gt;=3.10 &amp;&amp; &lt;3.12</CodeBlock>
-    <CodeBlock>Poetry &gt;=1.4.0 && &lt;2.x</CodeBlock>
+    {data.prerequisites.map((item) => (
+      <CodeBlock key={item}>{item}</CodeBlock>
+    ))}
   </div>
 );
-
-const quickstartItems = [
-  {
-    title: '1. Install Marketplace Client',
-    codeBlocks: [
-      'poetry new my_prj --python ">=3.10,<3.12" && cd my_prj',
-      'poetry add mech-client',
-    ],
-  },
-  {
-    title: '2. Configure Your Client',
-    codeBlocks: [
-      "echo MECHX_CHAIN_RPC='https://rpc.eu-central-2.gateway.fm/v4/gnosis/non-archival/mainnet' >> .env",
-    ],
-    moreItems: (
-      <>
-        <Paragraph>
-          Optional: For improved reliability, update .env with your custom RPC endpoint.
-        </Paragraph>
-        <CodeBlock canCopy>source .env</CodeBlock>
-      </>
-    ),
-  },
-  {
-    title: '3. Hire On-chain Agent',
-    codeBlocks: [
-      'poetry run mechx setup --chain-config gnosis',
-      'poetry run mechx request --prompts "Estimate the chance that Ethereum volatility exceeds 50,000 by the end of 2030" --priority-mech 0xb3c6319962484602b00d5587e965946890b82101 --tools superforcaster --chain-config gnosis',
-    ],
-  },
-];
 
 const Quickstart = () => (
   <Flex gap={24} vertical>
     <div>
       <Title level={4}>Quickstart</Title>
-      <Text>Get started with hiring an agent in three easy steps:</Text>
+      <Text>{data.quickstartIntro}</Text>
     </div>
     <Flex vertical>
-      {quickstartItems.map((item) => (
+      {data.quickstartItems.map((item) => (
         <div key={item.title} className="mb-20">
           <Paragraph>
             <Text strong>{item.title}</Text>
@@ -72,7 +44,16 @@ const Quickstart = () => (
                 {block}
               </CodeBlock>
             ))}
-            {item.moreItems}
+            {item.afterNote && (
+              <>
+                <Paragraph>{item.afterNote}</Paragraph>
+                {item.afterCodeBlocks?.map((block, index) => (
+                  <CodeBlock key={`${item.title}-after-${index}`} canCopy>
+                    {block}
+                  </CodeBlock>
+                ))}
+              </>
+            )}
           </div>
         </div>
       ))}
@@ -82,12 +63,9 @@ const Quickstart = () => (
 
 const AlertMessage = (
   <>
-    <p className="mt-0">
-      This quickstart covers the basics. For full details and advanced options, see the Olas Stack
-      Documentation.
-    </p>
+    <p className="mt-0">{data.alertText}</p>
     <Button type="default" size="large">
-      <a href={`${STACK_URL}/mech-client/`}>Explore Documentation</a>
+      <a href={`${STACK_URL}${data.docsLink}`}>Explore Documentation</a>
     </Button>
   </>
 );
@@ -96,7 +74,7 @@ export const HireAnAgent = () => (
   <PageWrapper>
     <HireContainer>
       <Title level={2} className="mb-0">
-        Hire an Agent on Olas Marketplace
+        {data.title}
       </Title>
       <Prerequisites />
       <Quickstart />

--- a/apps/build/components/MonetizeYourAgent/data.json
+++ b/apps/build/components/MonetizeYourAgent/data.json
@@ -1,6 +1,6 @@
 {
   "title": "Monetize your Agent on Olas Marketplace",
-  "prerequisites": ["Python >=3.10 && <3.14", "Poetry >=1.4.0 && <2.x", "Docker"],
+  "prerequisites": ["Python >=3.10 && <3.15", "Poetry >=1.4.0 && <2.x", "Docker"],
   "quickstartIntro": "Get started with monetizing your agent in five easy steps:",
   "quickstartItems": [
     {

--- a/apps/build/components/MonetizeYourAgent/data.json
+++ b/apps/build/components/MonetizeYourAgent/data.json
@@ -1,0 +1,71 @@
+{
+  "title": "Monetize your Agent on Olas Marketplace",
+  "prerequisites": ["Python >=3.10 && <3.12", "Poetry >=1.4.0 && <2.x", "Docker"],
+  "quickstartIntro": "Get started with monetizing your agent in five easy steps:",
+  "quickstartItems": [
+    {
+      "title": "1. Setup your workspace",
+      "description": "Run the setup command to create the workspace and deploy your mech - i.e. your AI agent that offers a service to other AI agents - on-chain:",
+      "codeBlocks": ["poetry run mech setup -c <chain>"]
+    },
+    {
+      "title": "2. Scaffold a tool",
+      "description": "Create a new tool using the CLI:",
+      "codeBlocks": ["poetry run mech add-tool <author> <tool_name> -d \"Tool description\""]
+    },
+    {
+      "title": "3. Implement your tool logic",
+      "contentBlocks": [
+        { "type": "text", "value": "Write your implementation in:" },
+        { "type": "code", "value": "~/.operate-mech/packages/<author>/customs/<tool_name>/<tool_name>.py" },
+        {
+          "type": "richText",
+          "segments": [
+            { "text": "The scaffold provides a template with a stubbed " },
+            { "text": "run()", "code": true },
+            { "text": " function. Extend the function to encapsulate the service your AI agent is offering." }
+          ]
+        },
+        {
+          "type": "note",
+          "title": "Note:",
+          "segments": [
+            { "text": "If your tool requires API keys or other secrets, add them to " },
+            { "text": "~/.operate-mech/.env", "code": true },
+            { "text": ". Tools can access the environment variables through kwargs.get(\"api_keys\") in the run() function" }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "4. Publish metadata",
+      "contentBlocks": [
+        { "type": "text", "value": "Generate metadata:" },
+        { "type": "code", "value": "poetry run mech prepare-metadata -c <chain>" },
+        {
+          "type": "note",
+          "title": "Offchain support:",
+          "segments": [
+            { "text": "Mechs also support offchain requests. If you'd like to host your mech and make it accessible over HTTP, you can set a public URL using the " },
+            { "text": "--offchain-url", "code": true },
+            { "text": " flag when publishing metadata. This URL will be included in your mech's on-chain metadata, making it discoverable by other agents. The flag is optional — if omitted, the mech operates on-chain only as before." }
+          ],
+          "children": [
+            { "type": "text", "value": "With offchain URL (optional):" },
+            { "type": "code", "value": "poetry run mech prepare-metadata -c <chain> --offchain-url https://your-mech.example.com/" }
+          ]
+        },
+        { "type": "text", "value": "Then update metadata on-chain:" },
+        { "type": "code", "value": "poetry run mech update-metadata -c <chain>" }
+      ]
+    },
+    {
+      "title": "5. Launch the agent",
+      "description": "Start the mech to serve other AI agents with it:",
+      "codeBlocks": ["poetry run mech run -c <chain>"]
+    }
+  ],
+  "afterQuickstart": "You and anyone else can now hire your mech agent.",
+  "alertText": "This quickstart covers the basics. For full details and advanced options, see the Olas Stack Documentation.",
+  "docsLink": "/mech-tools-dev/"
+}

--- a/apps/build/components/MonetizeYourAgent/data.json
+++ b/apps/build/components/MonetizeYourAgent/data.json
@@ -1,6 +1,6 @@
 {
   "title": "Monetize your Agent on Olas Marketplace",
-  "prerequisites": ["Python >=3.10 && <3.12", "Poetry >=1.4.0 && <2.x", "Docker"],
+  "prerequisites": ["Python >=3.10 && <3.14", "Poetry >=1.4.0 && <2.x", "Docker"],
   "quickstartIntro": "Get started with monetizing your agent in five easy steps:",
   "quickstartItems": [
     {

--- a/apps/build/components/MonetizeYourAgent/index.tsx
+++ b/apps/build/components/MonetizeYourAgent/index.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import styled from 'styled-components';
 import { PageWrapper } from 'util/theme';
 
+import data from './data.json';
+
 const { Title, Paragraph, Text } = Typography;
 
 const MonetizeContainer = styled.div`
@@ -24,125 +26,129 @@ const StyledBlockquote = styled.blockquote`
   color: rgba(0, 0, 0, 0.65);
 `;
 
-const prerequisiteItems = ['Python >=3.10 && <3.12', 'Poetry >=1.4.0 && <2.x', 'Docker'];
+type TextSegment = {
+  text: string;
+  code?: boolean;
+};
+
+type ContentBlock =
+  | { type: 'text'; value: string }
+  | { type: 'code'; value: string }
+  | { type: 'richText'; segments: TextSegment[] }
+  | {
+      type: 'note';
+      title: string;
+      value?: string;
+      segments?: TextSegment[];
+      children?: ContentBlock[];
+    };
+
+const RichTextSegments = ({ segments }: { segments: TextSegment[] }) => (
+  <>
+    {segments.map((seg, i) =>
+      seg.code ? (
+        <Text key={i} code>
+          {seg.text}
+        </Text>
+      ) : (
+        <span key={i}>{seg.text}</span>
+      ),
+    )}
+  </>
+);
+
+const ContentBlockRenderer = ({ block }: { block: ContentBlock }) => {
+  switch (block.type) {
+    case 'text':
+      return <Paragraph>{block.value}</Paragraph>;
+    case 'code':
+      return <CodeBlock canCopy>{block.value}</CodeBlock>;
+    case 'richText':
+      return (
+        <Paragraph>
+          <RichTextSegments segments={block.segments} />
+        </Paragraph>
+      );
+    case 'note':
+      return (
+        <StyledBlockquote>
+          <Text strong>{block.title}</Text>{' '}
+          {block.segments ? <RichTextSegments segments={block.segments} /> : block.value}
+          {block.children && (
+            <>
+              <br />
+              <br />
+              {block.children.map((child, index) => (
+                <ContentBlockRenderer key={index} block={child} />
+              ))}
+            </>
+          )}
+        </StyledBlockquote>
+      );
+    default:
+      return null;
+  }
+};
+
+type QuickstartItem = {
+  title: string;
+  description?: string;
+  contentBlocks?: ContentBlock[];
+  codeBlocks?: string[];
+};
 
 const Prerequisites = () => (
   <div>
     <Title level={4} className="mb-16">
       Prerequisites
     </Title>
-    {prerequisiteItems.map((item) => (
+    {data.prerequisites.map((item) => (
       <CodeBlock key={item}>{item}</CodeBlock>
     ))}
   </div>
 );
 
-const IMPLEMENTATION_PATH = '~/.operate-mech/packages/<author>/customs/<tool_name>/<tool_name>.py';
-
-const quickstartItems = [
-  {
-    title: '1. Setup your workspace',
-    description:
-      'Run the setup command to create the workspace and deploy your mech - i.e. your AI agent that offers a service to other AI agents - on-chain:',
-    codeBlocks: ['poetry run mech setup -c <chain>'],
-  },
-  {
-    title: '2. Scaffold a tool',
-    description: 'Create a new tool using the CLI:',
-    codeBlocks: ['poetry run mech add-tool <author> <tool_name> -d "Tool description"'],
-  },
-  {
-    title: '3. Implement your tool logic',
-    description: (
-      <>
-        <Paragraph>Write your implementation in:</Paragraph>
-        <CodeBlock canCopy>{IMPLEMENTATION_PATH}</CodeBlock>
-        <Paragraph>
-          The scaffold provides a template with a stubbed <Text code>run()</Text> function. Extend
-          the function to encapsulate the service your AI agent is offering.
-        </Paragraph>
-        <StyledBlockquote>
-          <Text strong>Note:</Text> If your tool requires API keys or other secrets, add them to{' '}
-          <Text code>~/.operate-mech/.env</Text>. Tools can access the environment variables through
-          kwargs.get(&quot;api_keys&quot;) in the run() function
-        </StyledBlockquote>
-      </>
-    ),
-  },
-  {
-    title: '4. Publish metadata',
-    description: (
-      <>
-        <Paragraph>Generate metadata:</Paragraph>
-        <CodeBlock canCopy>{'poetry run mech prepare-metadata -c <chain>'}</CodeBlock>
-        <StyledBlockquote>
-          <Text strong>Offchain support:</Text> Mechs also support offchain requests. If you&apos;d
-          like to host your mech and make it accessible over HTTP, you can set a public URL using
-          the <Text code>--offchain-url</Text> flag when publishing metadata. This URL will be
-          included in your mech&apos;s on-chain metadata, making it discoverable by other agents.
-          The flag is optional — if omitted, the mech operates on-chain only as before.
-          <br />
-          <br />
-          <Paragraph>With offchain URL (optional):</Paragraph>
-          <CodeBlock canCopy>
-            {
-              'poetry run mech prepare-metadata -c <chain> --offchain-url https://your-mech.example.com/'
-            }
-          </CodeBlock>
-        </StyledBlockquote>
-        <Paragraph>Then update metadata on-chain:</Paragraph>
-        <CodeBlock canCopy>{'poetry run mech update-metadata -c <chain>'}</CodeBlock>
-      </>
-    ),
-    codeBlocks: [],
-  },
-  {
-    title: '5. Launch the agent',
-    description: 'Start the mech to serve other AI agents with it:',
-    codeBlocks: ['poetry run mech run -c <chain>'],
-  },
-];
-
 const Quickstart = () => (
   <Flex gap={24} vertical>
     <div>
       <Title level={4}>Quickstart</Title>
-      <Text>Get started with monetizing your agent in five easy steps:</Text>
+      <Text>{data.quickstartIntro}</Text>
     </div>
     <Flex vertical>
-      {quickstartItems.map((item) => (
+      {(data.quickstartItems as QuickstartItem[]).map((item) => (
         <div key={item.title} className="mb-20">
           <Paragraph>
             <Text strong>{item.title}</Text>
           </Paragraph>
-          {item.description &&
-            (typeof item.description === 'string' ? (
-              <>
-                <Paragraph>{item.description}</Paragraph>
-                {item.codeBlocks && (
-                  <div>
-                    {item.codeBlocks.map((block, index) => (
-                      <CodeBlock key={`${item.title}${index}`} canCopy>
-                        {block}
-                      </CodeBlock>
-                    ))}
-                  </div>
-                )}
-              </>
-            ) : (
-              <>
-                {item.description}
-                {item.codeBlocks && (
-                  <div>
-                    {item.codeBlocks.map((block, index) => (
-                      <CodeBlock key={`${item.title}${index}`} canCopy>
-                        {block}
-                      </CodeBlock>
-                    ))}
-                  </div>
-                )}
-              </>
-            ))}
+          {item.contentBlocks ? (
+            <>
+              {item.contentBlocks.map((block, index) => (
+                <ContentBlockRenderer key={`${item.title}-block-${index}`} block={block} />
+              ))}
+              {item.codeBlocks && item.codeBlocks.length > 0 && (
+                <div>
+                  {item.codeBlocks.map((block, index) => (
+                    <CodeBlock key={`${item.title}${index}`} canCopy>
+                      {block}
+                    </CodeBlock>
+                  ))}
+                </div>
+              )}
+            </>
+          ) : item.description ? (
+            <>
+              <Paragraph>{item.description}</Paragraph>
+              {item.codeBlocks && (
+                <div>
+                  {item.codeBlocks.map((block, index) => (
+                    <CodeBlock key={`${item.title}${index}`} canCopy>
+                      {block}
+                    </CodeBlock>
+                  ))}
+                </div>
+              )}
+            </>
+          ) : null}
         </div>
       ))}
     </Flex>
@@ -151,12 +157,9 @@ const Quickstart = () => (
 
 const AlertMessage = (
   <>
-    <p className="mt-0">
-      This quickstart covers the basics. For full details and advanced options, see the Olas Stack
-      Documentation.
-    </p>
+    <p className="mt-0">{data.alertText}</p>
     <Button type="default" size="large">
-      <a href={`${STACK_URL}/mech-tools-dev/`}>Explore Documentation</a>
+      <a href={`${STACK_URL}${data.docsLink}`}>Explore Documentation</a>
     </Button>
   </>
 );
@@ -165,7 +168,7 @@ export const MonetizeYourAgent = () => (
   <PageWrapper>
     <MonetizeContainer>
       <Title level={2} className="mt-0">
-        Monetize your Agent on Olas Marketplace
+        {data.title}
       </Title>
       <Prerequisites />
       <Quickstart />

--- a/apps/build/pages/api/ai-guide/[page].ts
+++ b/apps/build/pages/api/ai-guide/[page].ts
@@ -1,0 +1,159 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import buildData from 'components/BuildAnAgent/data.json';
+import hireData from 'components/HireAnAgent/data.json';
+import monetizeData from 'components/MonetizeYourAgent/data.json';
+
+const STACK_URL = 'https://stack.olas.network';
+
+type TextSegment = {
+  text: string;
+  code?: boolean;
+};
+
+type ContentBlock =
+  | { type: 'text'; value: string }
+  | { type: 'code'; value: string }
+  | { type: 'richText'; segments: TextSegment[] }
+  | {
+      type: 'note';
+      title: string;
+      value?: string;
+      segments?: TextSegment[];
+      children?: ContentBlock[];
+    };
+
+type QuickstartItem = {
+  title: string;
+  description?: string;
+  contentBlocks?: ContentBlock[];
+  codeBlocks?: string[];
+  afterNote?: string;
+  afterCodeBlocks?: string[];
+};
+
+function renderSegments(segments: TextSegment[]): string {
+  return segments.map((seg) => (seg.code ? `\`${seg.text}\`` : seg.text)).join('');
+}
+
+function renderContentBlock(block: ContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.value;
+    case 'code':
+      return `\`\`\`\n${block.value}\n\`\`\``;
+    case 'richText':
+      return renderSegments(block.segments);
+    case 'note': {
+      const body = block.segments ? renderSegments(block.segments) : (block.value ?? '');
+      const lines = [`> **${block.title}** ${body}`];
+      if (block.children) {
+        for (const child of block.children) {
+          const rendered = renderContentBlock(child);
+          lines.push(...rendered.split('\n').map((line) => `> ${line}`));
+        }
+      }
+      return lines.join('\n');
+    }
+    default:
+      return '';
+  }
+}
+
+function renderQuickstartItem(item: QuickstartItem): string {
+  const lines: string[] = [`### ${item.title}`];
+
+  if (item.contentBlocks) {
+    for (const block of item.contentBlocks) {
+      lines.push(renderContentBlock(block as ContentBlock));
+    }
+  } else if (item.description) {
+    lines.push(item.description);
+  }
+
+  if (item.codeBlocks && item.codeBlocks.length > 0) {
+    for (const block of item.codeBlocks) {
+      lines.push(`\`\`\`\n${block}\n\`\`\``);
+    }
+  }
+
+  if (item.afterNote) {
+    lines.push(item.afterNote);
+  }
+
+  if (item.afterCodeBlocks) {
+    for (const block of item.afterCodeBlocks) {
+      lines.push(`\`\`\`\n${block}\n\`\`\``);
+    }
+  }
+
+  return lines.join('\n\n');
+}
+
+function generateBuildGuide(): string {
+  const lines: string[] = [`# ${buildData.title}`, '## Resources'];
+
+  for (const resource of buildData.resources) {
+    lines.push(`- **${resource.label}**: [${resource.linkText}](${resource.link})`);
+  }
+
+  return lines.join('\n\n');
+}
+
+function generateQuickstartGuide(guideData: {
+  title: string;
+  prerequisites: string[];
+  quickstartIntro: string;
+  quickstartItems: QuickstartItem[];
+  alertText: string;
+  docsLink: string;
+  afterQuickstart?: string;
+}): string {
+  const lines: string[] = [
+    `# ${guideData.title}`,
+    '## Prerequisites',
+    ...guideData.prerequisites.map((p) => `- \`${p}\``),
+    '## Quickstart',
+    guideData.quickstartIntro,
+  ];
+
+  for (const item of guideData.quickstartItems) {
+    lines.push(renderQuickstartItem(item));
+  }
+
+  if (guideData.afterQuickstart) {
+    lines.push(guideData.afterQuickstart);
+  }
+
+  lines.push(
+    `---\n\n${guideData.alertText}\n\n[Explore Documentation](${STACK_URL}${guideData.docsLink})`,
+  );
+
+  return lines.join('\n\n');
+}
+
+const generators: Record<string, () => string> = {
+  build: generateBuildGuide,
+  hire: () => generateQuickstartGuide(hireData as Parameters<typeof generateQuickstartGuide>[0]),
+  monetize: () =>
+    generateQuickstartGuide(monetizeData as Parameters<typeof generateQuickstartGuide>[0]),
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { page } = req.query;
+
+  if (typeof page !== 'string' || !generators[page]) {
+    res
+      .status(404)
+      .send(
+        'Not found. Available guides: /api/ai-guide/build, /api/ai-guide/hire, /api/ai-guide/monetize',
+      );
+    return;
+  }
+
+  const markdown = generators[page]();
+
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Cache-Control', 's-maxage=86400, stale-while-revalidate');
+  res.status(200).send(markdown);
+}

--- a/apps/build/public/llms.txt
+++ b/apps/build/public/llms.txt
@@ -6,6 +6,14 @@
 
 Build is the Olas app for developers and businesses to create AI agents, monetize their work, and hire pre-built agents for various use cases.
 
+## AI Guides
+
+Detailed quickstart guides available as plain text:
+
+- Build an Agent: https://build.olas.network/api/ai-guide/build
+- Hire an Agent: https://build.olas.network/api/ai-guide/hire
+- Monetize Your Agent: https://build.olas.network/api/ai-guide/monetize
+
 ## Key Features
 
 - Build an Agent: Create custom AI agents with guided workflows
@@ -19,6 +27,7 @@ Build is the Olas app for developers and businesses to create AI agents, monetiz
 
 - Website: https://build.olas.network/
 - Documentation: https://build.olas.network/docs
+- Olas Stack: https://stack.olas.network/
 - Disclaimer: https://olas.network/disclaimer
 
 ## Technology


### PR DESCRIPTION
## Proposed changes

  Summary                                                                                                                                                                    
                                                                                                                                                                             
  - Extracts page content (prerequisites, quickstart steps, commands) from inline JSX constants into shared JSON data files, creating a single source of truth consumed by   
  both React components and a new API route                                                                                                                                  
  - Adds /api/ai-guide/{build,hire,monetize} API routes that serve page content as plain-text markdown for AI agents, with 24h CDN caching                                   
  - Updates llms.txt to link to the three AI guide endpoints                                                                                                                 
  - Bumps Python version upper bound from 3.12 to 3.14 in hire and monetize prerequisites                                                                                    
                                                                                                                                                                             
  Test plan                                                                                                                                                                  
                                                                                                                                                                             
  - Verify /hire, /monetize, and /build pages render identically to before (no styling or content changes)                                                                   
  - Verify /api/ai-guide/hire, /api/ai-guide/monetize, and /api/ai-guide/build return well-formatted markdown
  - Verify /api/ai-guide/nonexistent returns 404                                                                                                                             
  - Verify Cache-Control header is set on API responses     

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
