### PR TITLE
feat: use on-chain ERC-8004 metadata name when available

### DIFF
--- a/apps/marketplace/pages/api/erc8004/[network]/ai-agents/[serviceId].ts
+++ b/apps/marketplace/pages/api/erc8004/[network]/ai-agents/[serviceId].ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { IDENTITY_REGISTRY_UPGRADEABLE } from 'libs/util-contracts/src/lib/abiAndAddresses/identityRegistryUpgradeable';
@@ -44,6 +45,43 @@ type Erc8004Response = {
 const getImageUrl = (image: string | undefined) => {
   if (!image) return '';
   return image.replace('ipfs://', GATEWAY_URL);
+};
+
+// Minimal ABI fragment for ERC-8004 Identity Registry getMetadata
+const IDENTITY_REGISTRY_ABI = [
+  'function getMetadata(uint256 tokenId, string key) view returns (bytes)',
+];
+
+/**
+ * Attempt to read the on-chain "name" metadata from the ERC-8004 Identity Registry.
+ * Returns the custom name if set, or null if not available / empty / on error.
+ */
+const getOnChainName = async (
+  provider: ethers.JsonRpcProvider,
+  chainId: number,
+  tokenId: number,
+): Promise<string | null> => {
+  try {
+    const registryAddress =
+      IDENTITY_REGISTRY_UPGRADEABLE.addresses[
+        chainId as keyof typeof IDENTITY_REGISTRY_UPGRADEABLE.addresses
+      ];
+    if (!registryAddress) return null;
+
+    const contract = new ethers.Contract(registryAddress, IDENTITY_REGISTRY_ABI, provider);
+    const rawBytes: string = await contract.getMetadata(tokenId, 'name');
+
+    // Empty bytes means no metadata set
+    if (!rawBytes || rawBytes === '0x') return null;
+
+    const decoded = ethers.AbiCoder.defaultAbiCoder().decode(['string'], rawBytes);
+    const name = decoded[0] as string;
+
+    return name && name.trim().length > 0 ? name.trim() : null;
+  } catch {
+    // If RPC call fails or contract doesn't exist on this chain, fall back gracefully
+    return null;
+  }
 };
 
 export default async function handler(
@@ -165,8 +203,11 @@ export default async function handler(
       });
     }
 
-    const agentName = generateName(chainId, Number(serviceId));
-    const nameWithSuffix = `${agentName} by Olas`;
+    // Check on-chain ERC-8004 metadata for a custom name first,
+    // fall back to the deterministic generated name if not set.
+    const onChainName = await getOnChainName(registryCtx.provider, chainId, Number(serviceId));
+    const agentName = onChainName ?? generateName(chainId, Number(serviceId));
+    const nameWithSuffix = onChainName ? agentName : `${agentName} by Olas`;
 
     const response: Erc8004Response = {
       type: 'https://eips.ethereum.org/EIPS/eip-8004#registration-v1',


### PR DESCRIPTION
## Summary

Currently, agent names in the ERC-8004 tokenURI endpoint are generated using `generateName(chainId, serviceId)`, producing random names like "mubleep-pronke01". This ignores any custom name set on-chain via `setMetadata("name", ...)` on the Identity Registry.

This PR adds a check for on-chain metadata before falling back to the generated name:
1. Query `getMetadata(tokenId, "name")` on the ERC-8004 Identity Registry contract
2. If a custom name exists, use it directly (without the " by Olas" suffix)
3. Otherwise, fall back to `generateName()` + " by Olas" as before

### Changes
- Added `getOnChainName()` helper using a minimal ABI fragment for `getMetadata(uint256,string)`
- Uses the existing `ethers.JsonRpcProvider` from `buildServiceRegistryContext()` — no new dependencies
- Graceful error handling: if the RPC call fails or the contract doesn't exist on a chain, falls back silently to `generateName()`
- ABI-decodes the returned bytes as a string (matching the `abi.encode(["string"], [name])` encoding used by `setMetadata`)

## Motivation

Service operators who call `setMetadata` to set a custom agent name expect it to be reflected in the marketplace tokenURI. Currently, the on-chain data is completely ignored.

## Testing

- Tested with Service #57 on Ethereum mainnet which has custom metadata set via `setMetadata`
- Falls back gracefully to `generateName()` when no custom name exists or when `getMetadata` reverts
- No new dependencies added — uses ethers.js already present in the project