### PR TITLE
chore: force redeploy of all apps

### DIFF
--- a/apps/bond/.deploy-trigger
+++ b/apps/bond/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/build/.deploy-trigger
+++ b/apps/build/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/contribute/.deploy-trigger
+++ b/apps/contribute/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/docs/.deploy-trigger
+++ b/apps/docs/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/govern/.deploy-trigger
+++ b/apps/govern/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/launch/.deploy-trigger
+++ b/apps/launch/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/marketplace/.deploy-trigger
+++ b/apps/marketplace/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/operate/.deploy-trigger
+++ b/apps/operate/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21

--- a/apps/pearl-api/.deploy-trigger
+++ b/apps/pearl-api/.deploy-trigger
@@ -1,0 +1,4 @@
+Marker file to force a redeploy of this app.
+Bump the timestamp below to force another redeploy.
+
+last-bumped: 2026-04-21


### PR DESCRIPTION
## Summary

- Adds a `.deploy-trigger` marker file to each app so merging this PR forces Vercel to redeploy every app in the monorepo.
- Works around the ignored-build-step setting that blocks manual redeploys.
- Each file carries a `last-bumped` date — bump it in a follow-up PR if another forced redeploy is ever needed.

## Test plan

- [ ] Verify the PR shows Vercel preview builds for all 9 apps (bond, build, contribute, docs, govern, launch, marketplace, operate, pearl-api).
- [ ] After merge, confirm each production deployment is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)