### PR TITLE
fix(pearl-api): add Polygon to Web3Auth swap-owner chain configs

### DIFF
--- a/apps/pearl-api/utils/chain.ts
+++ b/apps/pearl-api/utils/chain.ts
@@ -1,4 +1,4 @@
-import { base, gnosis, mode, optimism } from 'viem/chains';
+import { base, gnosis, mode, optimism, polygon } from 'viem/chains';
 
 type ValueOf<T> = T[keyof T];
 
@@ -30,6 +30,11 @@ export const EvmChainDetails: Record<
     logo: 'https://cryptologos.cc/logos/optimism-ethereum-op-logo.png?v=040',
     explorer: optimism.blockExplorers?.default?.url || '',
   },
+  '137': {
+    displayName: 'Polygon',
+    logo: 'https://cryptologos.cc/logos/polygon-matic-logo.png?v=040',
+    explorer: polygon.blockExplorers?.default?.url || '',
+  },
 };
 
 export const EvmChainIdMap = {
@@ -37,6 +42,7 @@ export const EvmChainIdMap = {
   Base: 8453,
   Mode: 34443,
   Optimism: 10,
+  Polygon: 137,
 } as const;
 export type EvmChainId = (typeof EvmChainIdMap)[keyof typeof EvmChainIdMap];
 
@@ -45,6 +51,7 @@ export const EvmChainName = {
   [EvmChainIdMap.Base]: EvmChainDetails[EvmChainIdMap.Base].displayName,
   [EvmChainIdMap.Mode]: EvmChainDetails[EvmChainIdMap.Mode].displayName,
   [EvmChainIdMap.Optimism]: EvmChainDetails[EvmChainIdMap.Optimism].displayName,
+  [EvmChainIdMap.Polygon]: EvmChainDetails[EvmChainIdMap.Polygon].displayName,
 } as const;
 export type EvmChainName = ValueOf<typeof EvmChainName>;
 

--- a/apps/pearl-api/utils/web3auth.ts
+++ b/apps/pearl-api/utils/web3auth.ts
@@ -1,5 +1,5 @@
 import { CONNECTOR_NAMESPACES, CustomChainConfig } from '@web3auth/modal';
-import { base, Chain, gnosis, mode, optimism } from 'viem/chains';
+import { base, Chain, gnosis, mode, optimism, polygon } from 'viem/chains';
 
 import { EvmChainDetails, EvmChainIdMap } from './chain';
 
@@ -21,4 +21,5 @@ export const CHAIN_CONFIGS: Record<string, CustomChainConfig> = {
   base: toWeb3AuthChainConfig(base, EvmChainDetails[EvmChainIdMap.Base].logo),
   optimism: toWeb3AuthChainConfig(optimism, EvmChainDetails[EvmChainIdMap.Optimism].logo),
   mode: toWeb3AuthChainConfig(mode, EvmChainDetails[EvmChainIdMap.Mode].logo),
+  polygon: toWeb3AuthChainConfig(polygon, EvmChainDetails[EvmChainIdMap.Polygon].logo),
 };

--- a/apps/pearl-api/utils/web3auth.ts
+++ b/apps/pearl-api/utils/web3auth.ts
@@ -3,11 +3,15 @@ import { base, Chain, gnosis, mode, optimism, polygon } from 'viem/chains';
 
 import { EvmChainDetails, EvmChainIdMap } from './chain';
 
-const toWeb3AuthChainConfig = (chain: Chain, logo: string): CustomChainConfig => {
+const toWeb3AuthChainConfig = (
+  chain: Chain,
+  logo: string,
+  rpcTarget?: string,
+): CustomChainConfig => {
   return {
     chainNamespace: CONNECTOR_NAMESPACES.EIP155,
     chainId: `0x${chain.id.toString(16)}`,
-    rpcTarget: chain.rpcUrls.default.http[0],
+    rpcTarget: rpcTarget ?? chain.rpcUrls.default.http[0],
     displayName: chain.name,
     ticker: chain.nativeCurrency.symbol,
     tickerName: chain.nativeCurrency.name,
@@ -21,5 +25,9 @@ export const CHAIN_CONFIGS: Record<string, CustomChainConfig> = {
   base: toWeb3AuthChainConfig(base, EvmChainDetails[EvmChainIdMap.Base].logo),
   optimism: toWeb3AuthChainConfig(optimism, EvmChainDetails[EvmChainIdMap.Optimism].logo),
   mode: toWeb3AuthChainConfig(mode, EvmChainDetails[EvmChainIdMap.Mode].logo),
-  polygon: toWeb3AuthChainConfig(polygon, EvmChainDetails[EvmChainIdMap.Polygon].logo),
+  polygon: toWeb3AuthChainConfig(
+    polygon,
+    EvmChainDetails[EvmChainIdMap.Polygon].logo,
+    process.env.NEXT_PUBLIC_POLYGON_URL,
+  ),
 };


### PR DESCRIPTION
## Proposed changes

Adds Polygon (chain id `137`) to the Web3Auth swap-owner-session chain configs.

The swap-owner iframe (`pages/web3auth/swap-owner-session.tsx`) initialises Web3Auth with a `defaultChainId` derived from a query param. The provider then looks up that chain in `CHAIN_CONFIGS`:

```ts
const currentChain = Object.values(CHAIN_CONFIGS).find(
  (chain) => chain.chainId === defaultChainHex,
);
```

`CHAIN_CONFIGS` only contained gnosis / base / optimism / mode, so for `chainId=137` (Polymarket Trader / Polystrat in Pearl) the lookup returned `undefined`, the SDK initialised with no chain match, and `useWeb3Auth().initError` surfaced as:

> Error initializing Web3Auth: Invalid provider Config. Please provide chain

That toast is what users see in the screenshot from valory-xyz/olas-operate-app on the recovery `Approve with Backup Wallet` step. The frontend was passing `chainId=137` correctly; the fix has to live here.

## Fixes

Pearl recovery for Polymarket Trader (Polystrat) users — they hit this on `Forgot Password → Approve with Backup Wallet → Open Wallet`.

## Diff

- `apps/pearl-api/utils/chain.ts` — adds `polygon` to `viem/chains` import; adds `'137'` entry to `EvmChainDetails`, `Polygon: 137` to `EvmChainIdMap`, and the matching line to `EvmChainName`.
- `apps/pearl-api/utils/web3auth.ts` — adds `polygon` to `viem/chains` import and a `polygon: toWeb3AuthChainConfig(...)` entry to `CHAIN_CONFIGS`.

Additive, no existing behaviour changes.

## Verification

- `tsc --noEmit -p apps/pearl-api/tsconfig.json` → clean.
- `nx lint pearl-api` → clean (one pre-existing unrelated warning).
- Local repro: opened `http://localhost:3010/web3auth/swap-owner-session?chainId=137&...` — before the fix, "Invalid provider Config. Please provide chain"; after, the SDK initialised and reached the Web3Auth `connect()` call (failed only on the unrelated `localhost:3010` domain whitelist, which is a dashboard-side check).

## Follow-up (out of scope here)

The production Web3Auth project (`NEXT_PUBLIC_WEB3AUTH_CLIENT_ID`) may need Polygon added to its allowed-chains list on https://dashboard.web3auth.io. Worth a quick check by whoever owns the dashboard before this is exercised in prod.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Supply-chain checklist

_No dep / workflow / `.supply-chain/` changes — N/A._