### PR TITLE
chore(deps): migrate build's web3.ts code to viem

### DIFF
--- a/apps/build/common-util/functions/index.ts
+++ b/apps/build/common-util/functions/index.ts
@@ -1,4 +1,3 @@
-import Web3 from 'web3';
 import { RPC_URLS } from 'libs/util-constants/src';
 import {
   getProvider as getProviderFn,
@@ -7,14 +6,8 @@ import {
   getIsValidChainId as getIsValidChainIdFn,
   sendTransaction as sendTransactionFn,
 } from 'libs/util-functions/src';
+
 import { SUPPORTED_CHAINS } from 'components/Login';
-import {
-  DISPENSER,
-  TREASURY,
-  TOKENOMICS,
-  AGENT_REGISTRY,
-  COMPONENT_REGISTRY,
-} from 'libs/util-contracts/src/lib/abiAndAddresses';
 
 type ChainId = number | string;
 
@@ -23,10 +16,8 @@ export const getProvider = () => getProviderFn(SUPPORTED_CHAINS, RPC_URLS);
 export const getIsValidChainId = (chainId: ChainId) =>
   getIsValidChainIdFn(SUPPORTED_CHAINS, chainId);
 
-export const getChainIdOrDefaultToMainnet = (chainId: ChainId) => {
-  const x = getChainIdOrDefaultToMainnetFn(SUPPORTED_CHAINS, chainId);
-  return x;
-};
+export const getChainIdOrDefaultToMainnet = (chainId: ChainId) =>
+  getChainIdOrDefaultToMainnetFn(SUPPORTED_CHAINS, chainId);
 
 export const getChainId = (chainId = null) => getChainIdFn(SUPPORTED_CHAINS, chainId);
 
@@ -40,79 +31,3 @@ export const sendTransaction = (
     supportedChains: SUPPORTED_CHAINS,
     rpcUrls: RPC_URLS,
   });
-
-/**
- * returns the web3 details
- */
-const getWeb3Details = () => {
-  const chainId = getChainId();
-  const web3 = new Web3(getProvider());
-  return { web3, chainId };
-};
-
-/**
- * returns the contract instance
- * @param {Array} abi - abi of the contract
- * @param {String} contractAddress - address of the contract
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getContract = (abi: any, contractAddress: string) => {
-  const { web3 } = getWeb3Details();
-  const contract = new web3.eth.Contract(abi, contractAddress);
-  return contract;
-};
-
-export const getDispenserContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(
-    DISPENSER.abi,
-    DISPENSER.addresses[chainId as unknown as keyof typeof DISPENSER.addresses],
-  );
-  return contract;
-};
-
-export const getTreasuryContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(
-    TREASURY.abi,
-    TREASURY.addresses[chainId as unknown as keyof typeof TREASURY.addresses],
-  );
-  return contract;
-};
-
-export const getTokenomicsContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(
-    TOKENOMICS.abi,
-    TOKENOMICS.addresses[chainId as unknown as keyof typeof TOKENOMICS.addresses],
-  );
-  return contract;
-};
-
-export const getAgentContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(
-    AGENT_REGISTRY.abi,
-    AGENT_REGISTRY.addresses[chainId as unknown as keyof typeof AGENT_REGISTRY.addresses],
-  );
-  return contract;
-};
-
-export const getComponentContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(
-    COMPONENT_REGISTRY.abi,
-    COMPONENT_REGISTRY.addresses[chainId as unknown as keyof typeof COMPONENT_REGISTRY.addresses],
-  );
-  return contract;
-};
-
-/**
- * TODO: move to autonolas-library and figure out a better way
- * to fetch timestamp
- */
-export const getBlockTimestamp = async (block = 'latest') => {
-  const { web3 } = getWeb3Details();
-  const temp = await web3.eth.getBlock(block);
-  return Number(temp.timestamp);
-};

--- a/apps/build/components/DevIncentives/ClaimIncentives.tsx
+++ b/apps/build/components/DevIncentives/ClaimIncentives.tsx
@@ -18,8 +18,10 @@ export const ClaimIncentives = () => {
   useEffect(() => {
     const getData = async () => {
       try {
+        // Treasury `paused()` returns a uint8 (0/1/2 — three pause states);
+        // `pauseValue` is compared as a string downstream (`=== '0' / '1' / '2'`).
         const value = await getPausedValueRequest();
-        setPausedValue(value);
+        setPausedValue(String(value));
       } catch (error: unknown) {
         notifySpecificError(error as Error);
         console.error(error);

--- a/apps/build/components/DevIncentives/IncentivesForThisEpoch.tsx
+++ b/apps/build/components/DevIncentives/IncentivesForThisEpoch.tsx
@@ -115,8 +115,8 @@ export const IncentivesForThisEpoch = () => {
             setRewardAndTopUp([
               {
                 key: '1',
-                reward: round(Number(parseToEth(response.reward)), 6),
-                topUp: round(Number(parseToEth(response.topUp)), 6),
+                reward: round(Number(parseToEth(response.reward.toString())), 6),
+                topUp: round(Number(parseToEth(response.topUp.toString())), 6),
               },
             ]);
           } catch (error: unknown) {

--- a/apps/build/components/DevIncentives/requests.ts
+++ b/apps/build/components/DevIncentives/requests.ts
@@ -1,19 +1,69 @@
-import { notifyError } from 'libs/util-functions/src';
-import { TOKENOMICS_UNIT_TYPES } from 'libs/util-constants/src';
-import { rewardsFormatter } from 'libs/common-contract-functions/src/lib/utils';
 import {
-  getAgentContract,
-  getBlockTimestamp,
-  getComponentContract,
-  getDispenserContract,
-  getTokenomicsContract,
-  getTreasuryContract,
-  sendTransaction,
-} from 'common-util/functions';
+  getBlock,
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from '@wagmi/core';
+import { Abi, Address } from 'viem';
 
-/**
- * fetches the owners of the units
- */
+import { rewardsFormatter } from 'libs/common-contract-functions/src/lib/utils';
+import { TOKENOMICS_UNIT_TYPES } from 'libs/util-constants/src';
+import {
+  AGENT_REGISTRY,
+  COMPONENT_REGISTRY,
+  DISPENSER,
+  TOKENOMICS,
+  TREASURY,
+} from 'libs/util-contracts/src/lib/abiAndAddresses';
+import { notifyError } from 'libs/util-functions/src';
+
+import { wagmiConfig } from 'components/Login/config';
+
+import { getChainId } from 'common-util/functions';
+
+const requireChainId = (): number => {
+  const chainId = getChainId();
+  if (chainId === undefined) throw new Error('Cannot determine chain ID');
+  return chainId;
+};
+
+const tokenomicsParams = (chainId: number) => ({
+  address: TOKENOMICS.addresses[chainId as keyof typeof TOKENOMICS.addresses] as Address,
+  abi: TOKENOMICS.abi,
+  chainId,
+});
+
+const treasuryParams = (chainId: number) => ({
+  address: TREASURY.addresses[chainId as keyof typeof TREASURY.addresses] as Address,
+  abi: TREASURY.abi,
+  chainId,
+});
+
+const dispenserParams = (chainId: number) => ({
+  address: DISPENSER.addresses[chainId as keyof typeof DISPENSER.addresses] as Address,
+  abi: DISPENSER.abi,
+  chainId,
+});
+
+// agent / component registry ABIs are not declared `as const` in the source `.js`
+// files, so viem can't infer return types — `as Abi` is required and the
+// `ownerOf` return must be cast manually.
+const agentParams = (chainId: number) => ({
+  address: AGENT_REGISTRY.addresses[chainId as keyof typeof AGENT_REGISTRY.addresses] as Address,
+  abi: AGENT_REGISTRY.abi as Abi,
+  chainId,
+});
+
+const componentParams = (chainId: number) => ({
+  address: COMPONENT_REGISTRY.addresses[
+    chainId as keyof typeof COMPONENT_REGISTRY.addresses
+  ] as Address,
+  abi: COMPONENT_REGISTRY.abi as Abi,
+  chainId,
+});
+
+/** Fetches the owners of the units. */
 export const getOwnersForUnits = async ({
   unitIds,
   unitTypes,
@@ -21,25 +71,23 @@ export const getOwnersForUnits = async ({
   unitIds: string[];
   unitTypes: string[];
 }) => {
-  const ownersList = [];
+  const chainId = requireChainId();
 
-  const agentContract = getAgentContract();
-  const componentContract = getComponentContract();
-
-  for (let i = 0; i < unitIds.length; i += 1) {
+  const ownersList = unitIds.map((unitId, i) => {
     // 1 = agent, 0 = component
-    if (unitTypes[i] === TOKENOMICS_UNIT_TYPES.AGENT) {
-      const result = agentContract.methods.ownerOf(unitIds[i]).call();
-      ownersList.push(result);
-    } else {
-      const result = componentContract.methods.ownerOf(unitIds[i]).call();
-      ownersList.push(result);
-    }
-  }
+    const params =
+      unitTypes[i] === TOKENOMICS_UNIT_TYPES.AGENT
+        ? agentParams(chainId)
+        : componentParams(chainId);
 
-  const list = await Promise.all(ownersList);
-  const results = await Promise.all(list.map((e) => e));
-  return results;
+    return readContract(wagmiConfig, {
+      ...params,
+      functionName: 'ownerOf',
+      args: [BigInt(unitId)],
+    }) as Promise<Address>;
+  });
+
+  return Promise.all(ownersList);
 };
 
 export const getOwnerIncentivesRequest = async ({
@@ -51,11 +99,13 @@ export const getOwnerIncentivesRequest = async ({
   unitTypes: string[];
   unitIds: string[];
 }) => {
-  const contract = getTokenomicsContract();
-  const response: { reward: string; topUp: string } = await contract.methods
-    .getOwnerIncentives(address, unitTypes, unitIds)
-    .call();
-  return response;
+  const chainId = requireChainId();
+  const [reward, topUp] = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'getOwnerIncentives',
+    args: [address as Address, unitTypes.map(BigInt), unitIds.map(BigInt)],
+  });
+  return { reward, topUp };
 };
 
 export const claimOwnerIncentivesRequest = async ({
@@ -67,44 +117,69 @@ export const claimOwnerIncentivesRequest = async ({
   unitTypes: string[];
   unitIds: string[];
 }) => {
-  const contract = getDispenserContract();
-  const fn = contract.methods.claimOwnerIncentives(unitTypes, unitIds).send({ from: account });
-
-  const response = (await sendTransaction(fn, account)) as unknown as { transactionHash?: string };
-  return response?.transactionHash;
+  const chainId = requireChainId();
+  const { request } = await simulateContract(wagmiConfig, {
+    ...dispenserParams(chainId),
+    functionName: 'claimOwnerIncentives',
+    args: [unitTypes.map(BigInt), unitIds.map(BigInt)],
+    account: account as Address,
+  });
+  const hash = await writeContract(wagmiConfig, request);
+  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash });
+  return receipt.transactionHash;
 };
 
 export const checkpointRequest = async ({ account }: { account: string }) => {
-  const contract = getTokenomicsContract();
-  const fn = contract.methods.checkpoint().send({ from: account });
-  const response = await sendTransaction(fn, account);
-  return response;
+  const chainId = requireChainId();
+  const { request } = await simulateContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'checkpoint',
+    account: account as Address,
+  });
+  const hash = await writeContract(wagmiConfig, request);
+  return waitForTransactionReceipt(wagmiConfig, { hash });
 };
 
 export const getEpochCounter = async () => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.epochCounter().call();
-  return parseInt(response, 10);
+  const chainId = requireChainId();
+  const response = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'epochCounter',
+  });
+  return Number(response);
 };
 
 const getEpochTokenomics = async (epochNum: number) => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.mapEpochTokenomics(epochNum).call();
-  return response;
+  const chainId = requireChainId();
+  return readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'mapEpochTokenomics',
+    args: [BigInt(epochNum)],
+  });
 };
 
 const getEpochLength = async () => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.epochLen().call();
-  return parseInt(response, 10);
+  const chainId = requireChainId();
+  const response = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'epochLen',
+  });
+  return Number(response);
+};
+
+const getBlockTimestamp = async () => {
+  const chainId = requireChainId();
+  const block = await getBlock(wagmiConfig, { blockTag: 'latest', chainId });
+  return Number(block.timestamp);
 };
 
 const getEpochDetails = async () => {
   const epCounter = await getEpochCounter();
-  const epTokenomics = await getEpochTokenomics(Number(epCounter) - 1);
+  const epTokenomics = await getEpochTokenomics(epCounter - 1);
   const epochLen = await getEpochLength();
   const blockTimestamp = await getBlockTimestamp();
-  const timeDiff = blockTimestamp - epTokenomics.endTime;
+  // `endTime` is a uint32 — viem returns it as `number` from the inferred ABI shape.
+  const timeDiff = blockTimestamp - Number(epTokenomics.endTime);
 
   return { timeDiff, epochLen };
 };
@@ -120,20 +195,25 @@ export const canShowCheckpoint = async () => {
   return false;
 };
 
+// Treasury `paused()` is a uint8 with three states (0 = unpaused, 1 = paused for
+// claiming only, 2 = fully paused), not a bool. Returns `number`.
 export const getPausedValueRequest = async () => {
-  const contract = getTreasuryContract();
-  const response = await contract.methods.paused().call();
-  return response;
+  const chainId = requireChainId();
+  const response = await readContract(wagmiConfig, {
+    ...treasuryParams(chainId),
+    functionName: 'paused',
+  });
+  return Number(response);
 };
 
 export const getLastEpochRequest = async () => {
   try {
     const epCounter = await getEpochCounter();
-    const prevEpochPoint = await getEpochTokenomics(Number(epCounter) - 1);
+    const prevEpochPoint = await getEpochTokenomics(epCounter - 1);
 
-    const prevEpochEndTime = prevEpochPoint.endTime;
+    const prevEpochEndTime = Number(prevEpochPoint.endTime);
     const epochLen = await getEpochLength();
-    const nextEpochEndTime = parseInt(prevEpochEndTime, 10) + epochLen;
+    const nextEpochEndTime = prevEpochEndTime + epochLen;
 
     return { epochLen, prevEpochEndTime, nextEpochEndTime };
   } catch (error) {
@@ -152,13 +232,17 @@ export const getPendingIncentives = async ({
   unitType: string;
   unitId: string;
 }) => {
-  const contract = getTokenomicsContract();
-
+  const chainId = requireChainId();
   const currentEpochCounter = await getEpochCounter();
 
-  const unitIncentives = await contract.methods.mapUnitIncentives(unitType, unitId).call();
-
-  const { pendingRelativeReward, pendingRelativeTopUp, lastEpoch } = unitIncentives;
+  // mapUnitIncentives returns 5 top-level outputs (uint96, uint96, uint96, uint96,
+  // uint32), so viem decodes it as a tuple — not an object with named fields.
+  const unitIncentives = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'mapUnitIncentives',
+    args: [BigInt(unitType), BigInt(unitId)],
+  });
+  const [, pendingRelativeReward, , pendingRelativeTopUp, lastEpoch] = unitIncentives;
 
   const isCurrentEpochWithReward =
     currentEpochCounter === Number(lastEpoch) && pendingRelativeReward > BIG_INT_0;
@@ -171,31 +255,35 @@ export const getPendingIncentives = async ({
     };
   }
 
-  // Get the unit points of the current epoch
-  const unitInfo = await contract.methods.getUnitPoint(currentEpochCounter, unitType).call();
+  // getUnitPoint returns a struct with mixed uint8 (number) and uint96 (bigint)
+  // fields. The uint8 fields must be wrapped in BigInt() before multiplying with
+  // uint96 bigints — mixing throws `Cannot mix BigInt and other types`.
+  const unitInfo = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'getUnitPoint',
+    args: [BigInt(currentEpochCounter), BigInt(unitType)],
+  });
 
-  const pendingReward =
-    (BigInt(pendingRelativeReward) * BigInt(unitInfo.rewardUnitFraction)) / BIG_INT_100;
+  const pendingReward = (pendingRelativeReward * BigInt(unitInfo.rewardUnitFraction)) / BIG_INT_100;
 
-  let totalIncentives = BigInt(pendingRelativeTopUp);
+  let totalIncentives = pendingRelativeTopUp;
   let pendingTopUp = BIG_INT_0;
 
-  /**
-   * the below calculation is done to get the reward and topup
-   * based on current epoch length
-   */
   if (totalIncentives > BIG_INT_0) {
-    const inflationPerSecond = await contract.methods.inflationPerSecond().call();
+    const inflationPerSecond = await readContract(wagmiConfig, {
+      ...tokenomicsParams(chainId),
+      functionName: 'inflationPerSecond',
+    });
 
     const { timeDiff, epochLen } = await getEpochDetails();
     const epochLength = timeDiff > epochLen ? timeDiff : epochLen;
 
-    const totalTopUps = inflationPerSecond * epochLength;
-    totalIncentives *= BigInt(totalTopUps);
+    const totalTopUps = inflationPerSecond * BigInt(epochLength);
+    totalIncentives *= totalTopUps;
 
     pendingTopUp =
-      (BigInt(totalIncentives) * BigInt(unitInfo.topUpUnitFraction)) /
-      (BigInt(unitInfo.sumUnitTopUpsOLAS) * BIG_INT_100);
+      (totalIncentives * BigInt(unitInfo.topUpUnitFraction)) /
+      (unitInfo.sumUnitTopUpsOLAS * BIG_INT_100);
   }
 
   return {


### PR DESCRIPTION
PR #3 of the web3.js -> viem modernization. Build's contract helpers (getDispenserContract, getTreasuryContract, getTokenomicsContract, getAgentContract, getComponentContract) and getBlockTimestamp utility were the last web3.js consumers; they're dropped in favor of direct @wagmi/core calls.

apps/build/common-util/functions/index.ts
- Removed: getWeb3Details, getContract (internal), getDispenserContract, getTreasuryContract, getTokenomicsContract, getAgentContract, getComponentContract, getBlockTimestamp.
- Kept: getProvider, getChainId, getChainIdOrDefaultToMainnet, getIsValidChainId, sendTransaction (all wrap libs/util-functions and are independent of web3.js).
- Drops the web3 import entirely.

apps/build/components/DevIncentives/requests.ts
- Sole consumer of the deleted helpers. Rewritten end-to-end:
  - 10 reads (.methods.foo().call()) -> readContract(wagmiConfig, ...)
  - 2 writes (.methods.foo().send()) -> simulateContract + writeContract
    + waitForTransactionReceipt
  - getBlockTimestamp (web3.eth.getBlock) -> getBlock from @wagmi/core
- Per-contract `*Params(chainId)` helpers consolidate address/abi/chainId threading.
- bigint output handling: epochCounter / epochLen / inflationPerSecond now properly typed as bigint and coerced where needed (parseInt(str) -> Number(bigint)). Caller (getPendingIncentives) already used BigInt arithmetic, so calculations are unchanged.

apps/build/components/DevIncentives/ClaimIncentives.tsx
- `paused()` returns bool in Solidity. web3.js 1.x returned native boolean but typed it as `any` from `.call()`, so the local state `useState('0')` silently accepted boolean assignment. Viem's strict return typing catches the mismatch. Minimal fix preserves the existing (buggy) `pauseValue === '0'` comparison logic by coercing with String(value) at the assignment site; the latent UI logic bug is out of scope for this migration.

Eliminates the web3.js import from build/. Remaining: bond (2), contribute (2), govern (1), marketplace (1).

Verification on this branch
- yarn nx build build: green
- yarn supply-chain: green (1 allowlisted bigint-buffer, 0 unlisted)
- build app has no spec files, so no Jest mocks to add

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## Fixes

<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Supply-chain checklist

_Only if this PR changes deps, workflows, or `.supply-chain/`. Full policy: [SUPPLY-CHAIN-SECURITY.md](../SUPPLY-CHAIN-SECURITY.md)._

- [x] `yarn supply-chain` passes locally.
- [ ] Any new/bumped dep is exact-pinned, ≥7 days old (or has a CVE), and reviewed.
- [ ] Any new GitHub Action is SHA-pinned.
