### PR TITLE
chore(deps): migrate bond's web3.js code to viem

### DIFF
--- a/apps/bond/common-util/Contracts/params.js
+++ b/apps/bond/common-util/Contracts/params.js
@@ -1,0 +1,42 @@
+import {
+  BOND_CALCULATOR,
+  DEPOSITORY,
+  ERC20_ABI,
+  TOKENOMICS,
+  UNISWAP_V2_PAIR_ABI,
+} from 'libs/util-contracts/src/lib/abiAndAddresses';
+
+import { ADDRESSES } from 'common-util/constants/addresses';
+
+// chainId is widened to `number` so wagmi's simulate/write/wait overloads
+// accept it against the workspace's non-const chains tuple.
+
+export const depositoryParams = (chainId) => ({
+  address: ADDRESSES[chainId].depository,
+  abi: DEPOSITORY.abi,
+  chainId: Number(chainId),
+});
+
+export const tokenomicsParams = (chainId) => ({
+  address: ADDRESSES[chainId].tokenomics,
+  abi: TOKENOMICS.abi,
+  chainId: Number(chainId),
+});
+
+export const bondCalculatorParams = (chainId) => ({
+  address: ADDRESSES[chainId].genericBondCalculator,
+  abi: BOND_CALCULATOR.abi,
+  chainId: Number(chainId),
+});
+
+export const uniswapV2PairParams = (address, chainId) => ({
+  address,
+  abi: UNISWAP_V2_PAIR_ABI,
+  chainId: Number(chainId),
+});
+
+export const erc20Params = (address, chainId) => ({
+  address,
+  abi: ERC20_ABI,
+  chainId: Number(chainId),
+});

--- a/apps/bond/common-util/Contracts/params.js
+++ b/apps/bond/common-util/Contracts/params.js
@@ -1,5 +1,4 @@
 import {
-  BOND_CALCULATOR,
   DEPOSITORY,
   ERC20_ABI,
   TOKENOMICS,
@@ -20,12 +19,6 @@ export const depositoryParams = (chainId) => ({
 export const tokenomicsParams = (chainId) => ({
   address: ADDRESSES[chainId].tokenomics,
   abi: TOKENOMICS.abi,
-  chainId: Number(chainId),
-});
-
-export const bondCalculatorParams = (chainId) => ({
-  address: ADDRESSES[chainId].genericBondCalculator,
-  abi: BOND_CALCULATOR.abi,
   chainId: Number(chainId),
 });
 

--- a/apps/bond/common-util/Login/LoginV2.jsx
+++ b/apps/bond/common-util/Login/LoginV2.jsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { useAccount, useBalance, useDisconnect } from 'wagmi';
-import Web3 from 'web3';
 
 import { CannotConnectAddressOfacError } from 'libs/ui-components/src';
 import { MEDIA_QUERY } from 'libs/ui-theme/src';
@@ -82,16 +81,10 @@ export const LoginV2 = ({ onConnect: onConnectCb, onDisconnect: onDisconnectCb }
           connector?.options?.getProvider?.() || (await connector?.getProvider?.());
 
         if (modalProvider) {
-          // We plug the initial `provider` and get back
-          // a Web3Provider. This will add on methods and
-          // event listeners such as `.on()` will be different.
-          const wProvider = new Web3(modalProvider);
-
-          // *******************************************************
-          // ************ setting to the window object! ************
-          // *******************************************************
+          // libs/util-functions/getModalProvider reads window.MODAL_PROVIDER
+          // for the legacy gnosis-safe polling path. The previous web3-instance
+          // mirror (window.WEB3_PROVIDER) had no readers anywhere in the repo.
           window.MODAL_PROVIDER = modalProvider;
-          window.WEB3_PROVIDER = wProvider;
 
           if (modalProvider?.on) {
             // https://docs.ethers.io/v5/concepts/best-practices/#best-practices--network-changes

--- a/apps/bond/common-util/functions/ethers.js
+++ b/apps/bond/common-util/functions/ethers.js
@@ -20,12 +20,3 @@ export const parseToSolDecimals = (amount) => ethers.parseUnits(`${amount}`, 8).
  * divides the amount by 10^8
  */
 export const parseToSol = (amount) => ethers.formatUnits(`${amount}`, 8);
-
-/**
- * TODO: move to autonolas-library and figure out a better way
- * to fetch timestamp
- */
-export const getBlockTimestamp = async (block = 'latest') => {
-  const temp = await window?.WEB3_PROVIDER.eth.getBlock(block);
-  return temp.timestamp * 1;
-};

--- a/apps/bond/common-util/functions/web3.js
+++ b/apps/bond/common-util/functions/web3.js
@@ -1,55 +1,13 @@
 import { createPublicClient, getContract as getViemContract, http } from 'viem';
-import Web3 from 'web3';
 
 import { CHAINS, RPC_URLS } from 'libs/util-constants/src';
-import {
-  BOND_CALCULATOR,
-  DEPOSITORY,
-  ERC20_ABI,
-  TOKENOMICS,
-  UNISWAP_V2_PAIR_ABI,
-} from 'libs/util-contracts/src/lib/abiAndAddresses';
-
-import { ADDRESSES } from 'common-util/constants/addresses';
-import { getChainId, getProvider } from 'common-util/functions/frontend-library';
+import { UNISWAP_V2_PAIR_ABI } from 'libs/util-contracts/src/lib/abiAndAddresses';
 
 /**
- * returns the web3 details
+ * Returns a viem contract instance bound to a public client for the given chain.
+ * Used for cross-chain LP price reads where the connected wallet's chain
+ * doesn't match the LP's chain.
  */
-const getWeb3Details = () => {
-  const chainId = getChainId();
-  const web3 = new Web3(getProvider());
-  return { web3, chainId };
-};
-
-/**
- * returns the contract instance
- * @param {Array} abi - abi of the contract
- * @param {String} contractAddress - address of the contract
- */
-const getContract = (abi, contractAddress) => {
-  const { web3 } = getWeb3Details();
-  const contract = new web3.eth.Contract(abi, contractAddress);
-  return contract;
-};
-
-export const getDepositoryContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(DEPOSITORY.abi, ADDRESSES[chainId].depository);
-  return contract;
-};
-
-export const getTokenomicsContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(TOKENOMICS.abi, ADDRESSES[chainId].tokenomics);
-  return contract;
-};
-
-export const getUniswapV2PairContract = (address) => {
-  const contract = getContract(UNISWAP_V2_PAIR_ABI, address);
-  return contract;
-};
-
 export const getUniswapV2PairContractByChain = (address, chainId) => {
   const chain = CHAINS[chainId];
   if (!chain) {
@@ -57,26 +15,13 @@ export const getUniswapV2PairContractByChain = (address, chainId) => {
   }
 
   const publicClient = createPublicClient({
-    chain: chain,
+    chain,
     transport: http(RPC_URLS[chainId] || chain.rpcUrls[0].http),
   });
 
-  const contract = getViemContract({
-    address: address,
+  return getViemContract({
+    address,
     abi: UNISWAP_V2_PAIR_ABI,
     client: publicClient,
   });
-
-  return contract;
-};
-
-export const getErc20Contract = (address) => {
-  const contract = getContract(ERC20_ABI, address);
-  return contract;
-};
-
-export const getGenericBondCalculatorContract = () => {
-  const { chainId } = getWeb3Details();
-  const contract = getContract(BOND_CALCULATOR.abi, ADDRESSES[chainId].genericBondCalculator);
-  return contract;
 };

--- a/apps/bond/components/BondingProducts/Bonding/BondingList/useBondingList.jsx
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/useBondingList.jsx
@@ -1,3 +1,4 @@
+import { readContract } from '@wagmi/core';
 import { ethers } from 'ethers';
 import { find, memoize, round } from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
@@ -9,19 +10,20 @@ import { VM_TYPE } from 'libs/util-constants/src';
 
 import { DEPOSITORY } from 'libs/util-contracts/src/lib/abiAndAddresses';
 
+import { wagmiConfig } from 'common-util/config/wagmi';
 import { ADDRESSES } from 'common-util/constants/addresses';
 import { ADDRESS_ZERO, ONE_ETH } from 'common-util/constants/numbers';
+import {
+  depositoryParams,
+  erc20Params,
+  tokenomicsParams,
+  uniswapV2PairParams,
+} from 'common-util/Contracts/params';
 import { DEX } from 'common-util/enums';
 import { notifySpecificError } from 'common-util/functions/errors';
 import { parseToEth } from 'common-util/functions/ethers';
 import { getChainId } from 'common-util/functions/frontend-library';
-import {
-  getDepositoryContract,
-  getErc20Contract,
-  getTokenomicsContract,
-  getUniswapV2PairContract,
-  getUniswapV2PairContractByChain,
-} from 'common-util/functions/web3';
+import { getUniswapV2PairContractByChain } from 'common-util/functions/web3';
 import { BALANCER_GRAPH_CLIENTS } from 'common-util/graphql/clients';
 import { balancerGetPoolQuery } from 'common-util/graphql/queries';
 import { useHelpers } from 'common-util/hooks/useHelpers';
@@ -126,8 +128,11 @@ export const isSvmLpAddress = (address) =>
  * fetches the IDF (discount factor) for the product
  */
 const getLastIDFRequest = async () => {
-  const contract = getTokenomicsContract();
-  const lastIdfResponse = await contract.methods.getLastIDF().call();
+  const chainId = getChainId();
+  const lastIdfResponse = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'getLastIDF',
+  });
 
   /**
    * 1 ETH = 1e18
@@ -159,13 +164,21 @@ const getLpTokenDetails = memoize(async (address) => {
   const chainId = getChainId();
   let tokenSymbol = null;
   try {
-    const contract = getUniswapV2PairContract(address);
-    const token0 = await contract.methods.token0().call();
-    const token1 = await contract.methods.token1().call();
-    const erc20Contract = getErc20Contract(
-      token0 === ADDRESSES[chainId].olasAddress ? token1 : token0,
-    );
-    tokenSymbol = await erc20Contract.methods.symbol().call();
+    const [token0, token1] = await Promise.all([
+      readContract(wagmiConfig, {
+        ...uniswapV2PairParams(address, chainId),
+        functionName: 'token0',
+      }),
+      readContract(wagmiConfig, {
+        ...uniswapV2PairParams(address, chainId),
+        functionName: 'token1',
+      }),
+    ]);
+    const erc20Address = token0 === ADDRESSES[chainId].olasAddress ? token1 : token0;
+    tokenSymbol = await readContract(wagmiConfig, {
+      ...erc20Params(erc20Address, chainId),
+      functionName: 'symbol',
+    });
   } catch (error) {
     console.error('Error fetching token0 and token1 from the LP pair contract: ', address);
   }
@@ -531,8 +544,12 @@ const useProductListRequest = ({ isActive }) => {
   const getProductDetailsFromIds = useProductDetailsFromIds();
 
   return useCallback(async () => {
-    const contract = getDepositoryContract();
-    const productIdList = await contract.methods.getProducts(isActive).call();
+    const chainId = getChainId();
+    const productIdList = await readContract(wagmiConfig, {
+      ...depositoryParams(chainId),
+      functionName: 'getProducts',
+      args: [isActive],
+    });
     const response = await getProductDetailsFromIds(productIdList);
 
     const productList = response.map((product, index) => ({

--- a/apps/bond/components/BondingProducts/Bonding/Deposit/useDeposit.jsx
+++ b/apps/bond/components/BondingProducts/Bonding/Deposit/useDeposit.jsx
@@ -1,13 +1,14 @@
+import {
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from '@wagmi/core';
 import { useCallback } from 'react';
 
-import { getEstimatedGasLimit } from 'libs/util-functions/src';
-
+import { wagmiConfig } from 'common-util/config/wagmi';
 import { ADDRESSES } from 'common-util/constants/addresses';
-import {
-  getDepositoryContract,
-  getUniswapV2PairContract,
-  sendTransaction,
-} from 'common-util/functions';
+import { depositoryParams, uniswapV2PairParams } from 'common-util/Contracts/params';
 import { useHelpers } from 'common-util/hooks/useHelpers';
 
 export const useDeposit = () => {
@@ -15,25 +16,29 @@ export const useDeposit = () => {
 
   const hasSufficientTokenRequest = useCallback(
     async ({ token: productToken, tokenAmount }) => {
-      const contract = getUniswapV2PairContract(productToken);
       const treasuryAddress = ADDRESSES[chainId].treasury;
-      const response = await contract.methods.allowance(account, treasuryAddress).call();
+      const response = await readContract(wagmiConfig, {
+        ...uniswapV2PairParams(productToken, chainId),
+        functionName: 'allowance',
+        args: [account, treasuryAddress],
+      });
 
       // if allowance is greater than or equal to token amount
       // then user has sufficient token
-      const hasEnoughAllowance = response >= tokenAmount;
-      return hasEnoughAllowance;
+      return BigInt(response) >= BigInt(tokenAmount);
     },
     [account, chainId],
   );
 
   const getLpBalanceRequest = useCallback(
     async ({ token }) => {
-      const contract = getUniswapV2PairContract(token);
-      const response = await contract.methods.balanceOf(account).call();
-      return response;
+      return readContract(wagmiConfig, {
+        ...uniswapV2PairParams(token, chainId),
+        functionName: 'balanceOf',
+        args: [account],
+      });
     },
-    [account],
+    [account, chainId],
   );
 
   /**
@@ -41,27 +46,32 @@ export const useDeposit = () => {
    */
   const approveRequest = useCallback(
     async ({ token, amountToApprove }) => {
-      const contract = getUniswapV2PairContract(token);
       const treasuryAddress = ADDRESSES[chainId].treasury;
-      const fnApprove = contract.methods.approve(treasuryAddress, amountToApprove);
-      const estimatedGas = await getEstimatedGasLimit(fnApprove, account);
-      const fn = fnApprove.send({ from: account, gasLimit: estimatedGas });
-
-      const response = await sendTransaction(fn, account);
-      return response;
+      const { request } = await simulateContract(wagmiConfig, {
+        ...uniswapV2PairParams(token, chainId),
+        functionName: 'approve',
+        args: [treasuryAddress, amountToApprove],
+        account,
+      });
+      const hash = await writeContract(wagmiConfig, request);
+      return waitForTransactionReceipt(wagmiConfig, { hash });
     },
     [account, chainId],
   );
 
   const depositRequest = useCallback(
     async ({ productId, tokenAmount }) => {
-      const contract = getDepositoryContract();
-      const fn = contract.methods.deposit(productId, tokenAmount).send({ from: account });
-
-      const response = await sendTransaction(fn, account);
-      return response?.transactionHash;
+      const { request } = await simulateContract(wagmiConfig, {
+        ...depositoryParams(chainId),
+        functionName: 'deposit',
+        args: [productId, tokenAmount],
+        account,
+      });
+      const hash = await writeContract(wagmiConfig, request);
+      const receipt = await waitForTransactionReceipt(wagmiConfig, { hash });
+      return receipt.transactionHash;
     },
-    [account],
+    [account, chainId],
   );
 
   return {

--- a/apps/bond/components/BondingProducts/requests.js
+++ b/apps/bond/components/BondingProducts/requests.js
@@ -27,7 +27,7 @@ export const getBondInfoRequest = async (bondList) => {
 
     return bondList.map((component, index) => ({
       ...component,
-      maturityDate: Number(lpTokenNameList[index].maturity) * 1000,
+      maturityDate: Number(lpTokenNameList[index][2]) * 1000,
     }));
   } catch (error) {
     window.console.log('Error on fetching bond info');
@@ -47,7 +47,7 @@ const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
     args: [account, isBondMatured],
   });
 
-  const { bondIds } = response;
+  const [bondIds] = response;
   const idsList = bondIds.map((id) => `${id}`);
 
   const allListResponse = await Promise.all(
@@ -60,8 +60,9 @@ const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
     ),
   );
 
-  const bondsListWithDetails = allListResponse.map((bond, index) => ({
-    ...bond,
+  const bondsListWithDetails = allListResponse.map(([payout, matured], index) => ({
+    payout,
+    matured,
     bondId: idsList[index],
     key: idsList[index],
   }));

--- a/apps/bond/components/BondingProducts/requests.js
+++ b/apps/bond/components/BondingProducts/requests.js
@@ -1,26 +1,33 @@
-import { notifyError } from 'libs/util-functions/src';
 import {
-  getDepositoryContract,
-  getTokenomicsContract,
-  sendTransaction,
-} from 'common-util/functions';
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from '@wagmi/core';
+
+import { notifyError } from 'libs/util-functions/src';
+
+import { wagmiConfig } from 'common-util/config/wagmi';
+import { depositoryParams, tokenomicsParams } from 'common-util/Contracts/params';
+import { getChainId } from 'common-util/functions/frontend-library';
 
 export const getBondInfoRequest = async (bondList) => {
-  const contract = getDepositoryContract();
+  const chainId = getChainId();
 
   try {
-    const bondListPromise = [];
-
-    for (let i = 0; i < bondList.length; i += 1) {
-      const result = contract.methods.mapUserBonds(bondList[i].bondId).call();
-      bondListPromise.push(result);
-    }
-
-    const lpTokenNameList = await Promise.all(bondListPromise);
+    const lpTokenNameList = await Promise.all(
+      bondList.map((bond) =>
+        readContract(wagmiConfig, {
+          ...depositoryParams(chainId),
+          functionName: 'mapUserBonds',
+          args: [bond.bondId],
+        }),
+      ),
+    );
 
     return bondList.map((component, index) => ({
       ...component,
-      maturityDate: lpTokenNameList[index].maturity * 1000,
+      maturityDate: Number(lpTokenNameList[index].maturity) * 1000,
     }));
   } catch (error) {
     window.console.log('Error on fetching bond info');
@@ -32,23 +39,27 @@ export const getBondInfoRequest = async (bondList) => {
  * Bonding functionalities
  */
 const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
-  const contract = getDepositoryContract();
+  const chainId = getChainId();
 
-  const response = await contract.methods.getBonds(account, isBondMatured).call();
+  const response = await readContract(wagmiConfig, {
+    ...depositoryParams(chainId),
+    functionName: 'getBonds',
+    args: [account, isBondMatured],
+  });
 
   const { bondIds } = response;
-  const allListPromise = [];
-  const idsList = [];
+  const idsList = bondIds.map((id) => `${id}`);
 
-  for (let i = 0; i < bondIds.length; i += 1) {
-    const id = `${bondIds[i]}`;
-    const result = contract.methods.getBondStatus(id).call();
+  const allListResponse = await Promise.all(
+    idsList.map((id) =>
+      readContract(wagmiConfig, {
+        ...depositoryParams(chainId),
+        functionName: 'getBondStatus',
+        args: [id],
+      }),
+    ),
+  );
 
-    allListPromise.push(result);
-    idsList.push(id);
-  }
-
-  const allListResponse = await Promise.all(allListPromise);
   const bondsListWithDetails = allListResponse.map((bond, index) => ({
     ...bond,
     bondId: idsList[index],
@@ -74,38 +85,53 @@ export const getAllBondsRequest = async ({ account }) => {
 };
 
 export const redeemRequest = async ({ account, bondIds }) => {
-  const contract = getDepositoryContract();
-  const fn = contract.methods.redeem(bondIds).send({ from: account });
-  const response = await sendTransaction(fn, account);
-  return response?.transactionHash;
+  const chainId = getChainId();
+  const { request } = await simulateContract(wagmiConfig, {
+    ...depositoryParams(chainId),
+    functionName: 'redeem',
+    args: [bondIds],
+    account,
+  });
+  const hash = await writeContract(wagmiConfig, request);
+  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash });
+  return receipt.transactionHash;
 };
 
 export const getEpochCounter = async () => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.epochCounter().call();
-  return parseInt(response, 10);
+  const chainId = getChainId();
+  const response = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'epochCounter',
+  });
+  return Number(response);
 };
 
 const getEpochTokenomics = async (epochNum) => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.mapEpochTokenomics(epochNum).call();
-  return response;
+  const chainId = getChainId();
+  return readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'mapEpochTokenomics',
+    args: [BigInt(epochNum)],
+  });
 };
 
 const getEpochLength = async () => {
-  const contract = getTokenomicsContract();
-  const response = await contract.methods.epochLen().call();
-  return parseInt(response, 10);
+  const chainId = getChainId();
+  const response = await readContract(wagmiConfig, {
+    ...tokenomicsParams(chainId),
+    functionName: 'epochLen',
+  });
+  return Number(response);
 };
 
 export const getLastEpochRequest = async () => {
   try {
     const epCounter = await getEpochCounter();
-    const prevEpochPoint = await getEpochTokenomics(Number(epCounter) - 1);
+    const prevEpochPoint = await getEpochTokenomics(epCounter - 1);
 
-    const prevEpochEndTime = prevEpochPoint.endTime;
+    const prevEpochEndTime = Number(prevEpochPoint.endTime);
     const epochLen = await getEpochLength();
-    const nextEpochEndTime = parseInt(prevEpochEndTime, 10) + epochLen;
+    const nextEpochEndTime = prevEpochEndTime + epochLen;
 
     return { epochLen, prevEpochEndTime, nextEpochEndTime };
   } catch (error) {

--- a/apps/bond/components/BondingProducts/requests.js
+++ b/apps/bond/components/BondingProducts/requests.js
@@ -25,10 +25,12 @@ export const getBondInfoRequest = async (bondList) => {
       ),
     );
 
-    return bondList.map((component, index) => ({
-      ...component,
-      maturityDate: Number(lpTokenNameList[index][2]) * 1000,
-    }));
+    return bondList.map((component, index) => {
+      // mapUserBonds returns (account, payout, maturity, productId) as a tuple;
+      // viem decodes multi-output reads positionally, not as a named object.
+      const [, , maturity] = lpTokenNameList[index];
+      return { ...component, maturityDate: Number(maturity) * 1000 };
+    });
   } catch (error) {
     window.console.log('Error on fetching bond info');
     return bondList;

--- a/apps/bond/components/MyBonds/requests.js
+++ b/apps/bond/components/MyBonds/requests.js
@@ -25,7 +25,7 @@ export const getBondInfoRequest = async (bondList) => {
 
     return bondList.map((component, index) => ({
       ...component,
-      maturityDate: Number(lpTokenNameList[index].maturity) * 1000,
+      maturityDate: Number(lpTokenNameList[index][2]) * 1000,
     }));
   } catch (error) {
     window.console.log('Error on fetching bond info');
@@ -42,7 +42,7 @@ const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
     args: [account, isBondMatured],
   });
 
-  const { bondIds } = response;
+  const [bondIds] = response;
   const idsList = bondIds.map((id) => `${id}`);
 
   const allListResponse = await Promise.all(
@@ -55,8 +55,9 @@ const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
     ),
   );
 
-  const bondsListWithDetails = allListResponse.map((bond, index) => ({
-    ...bond,
+  const bondsListWithDetails = allListResponse.map(([payout, matured], index) => ({
+    payout,
+    matured,
     bondId: idsList[index],
     key: idsList[index],
   }));

--- a/apps/bond/components/MyBonds/requests.js
+++ b/apps/bond/components/MyBonds/requests.js
@@ -23,10 +23,12 @@ export const getBondInfoRequest = async (bondList) => {
       ),
     );
 
-    return bondList.map((component, index) => ({
-      ...component,
-      maturityDate: Number(lpTokenNameList[index][2]) * 1000,
-    }));
+    return bondList.map((component, index) => {
+      // mapUserBonds returns (account, payout, maturity, productId) as a tuple;
+      // viem decodes multi-output reads positionally, not as a named object.
+      const [, , maturity] = lpTokenNameList[index];
+      return { ...component, maturityDate: Number(maturity) * 1000 };
+    });
   } catch (error) {
     window.console.log('Error on fetching bond info');
     return bondList;

--- a/apps/bond/components/MyBonds/requests.js
+++ b/apps/bond/components/MyBonds/requests.js
@@ -1,21 +1,31 @@
-import { getDepositoryContract, sendTransaction } from 'common-util/functions';
+import {
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from '@wagmi/core';
+
+import { wagmiConfig } from 'common-util/config/wagmi';
+import { depositoryParams } from 'common-util/Contracts/params';
+import { getChainId } from 'common-util/functions/frontend-library';
 
 export const getBondInfoRequest = async (bondList) => {
-  const contract = getDepositoryContract();
+  const chainId = getChainId();
 
   try {
-    const bondListPromise = [];
-
-    for (let i = 0; i < bondList.length; i += 1) {
-      const result = contract.methods.mapUserBonds(bondList[i].bondId).call();
-      bondListPromise.push(result);
-    }
-
-    const lpTokenNameList = await Promise.all(bondListPromise);
+    const lpTokenNameList = await Promise.all(
+      bondList.map((bond) =>
+        readContract(wagmiConfig, {
+          ...depositoryParams(chainId),
+          functionName: 'mapUserBonds',
+          args: [bond.bondId],
+        }),
+      ),
+    );
 
     return bondList.map((component, index) => ({
       ...component,
-      maturityDate: lpTokenNameList[index].maturity * 1000,
+      maturityDate: Number(lpTokenNameList[index].maturity) * 1000,
     }));
   } catch (error) {
     window.console.log('Error on fetching bond info');
@@ -24,23 +34,27 @@ export const getBondInfoRequest = async (bondList) => {
 };
 
 const getBondsRequest = async ({ account, isActive: isBondMatured }) => {
-  const contract = getDepositoryContract();
+  const chainId = getChainId();
 
-  const response = await contract.methods.getBonds(account, isBondMatured).call();
+  const response = await readContract(wagmiConfig, {
+    ...depositoryParams(chainId),
+    functionName: 'getBonds',
+    args: [account, isBondMatured],
+  });
 
   const { bondIds } = response;
-  const allListPromise = [];
-  const idsList = [];
+  const idsList = bondIds.map((id) => `${id}`);
 
-  for (let i = 0; i < bondIds.length; i += 1) {
-    const id = `${bondIds[i]}`;
-    const result = contract.methods.getBondStatus(id).call();
+  const allListResponse = await Promise.all(
+    idsList.map((id) =>
+      readContract(wagmiConfig, {
+        ...depositoryParams(chainId),
+        functionName: 'getBondStatus',
+        args: [id],
+      }),
+    ),
+  );
 
-    allListPromise.push(result);
-    idsList.push(id);
-  }
-
-  const allListResponse = await Promise.all(allListPromise);
   const bondsListWithDetails = allListResponse.map((bond, index) => ({
     ...bond,
     bondId: idsList[index],
@@ -66,8 +80,14 @@ export const getAllBondsRequest = async ({ account }) => {
 };
 
 export const redeemRequest = async ({ account, bondIds }) => {
-  const contract = getDepositoryContract();
-  const fn = contract.methods.redeem(bondIds).send({ from: account });
-  const response = await sendTransaction(fn, account);
-  return response?.transactionHash;
+  const chainId = getChainId();
+  const { request } = await simulateContract(wagmiConfig, {
+    ...depositoryParams(chainId),
+    functionName: 'redeem',
+    args: [bondIds],
+    account,
+  });
+  const hash = await writeContract(wagmiConfig, request);
+  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash });
+  return receipt.transactionHash;
 };


### PR DESCRIPTION
PR #6 of the web3.js -> viem modernization. Bond was the second-heaviest app to migrate — 4 caller files, 7 contract getters in common-util/functions/web3.js, and a Login web3-mirror that was dead code (same pattern as contribute had).

apps/bond/common-util/functions/web3.js
- Reduced to a single export: getUniswapV2PairContractByChain, which was already viem-based (returns a viem contract bound to a public client for cross-chain LP price reads).
- Removed: getWeb3Details, getContract (internal), getDepositoryContract, getTokenomicsContract, getUniswapV2PairContract, getErc20Contract, getGenericBondCalculatorContract (had zero callers — dead code).

apps/bond/common-util/Contracts/params.js (new)
- Per-contract `{ address, abi, chainId }` helpers: depositoryParams(chainId), tokenomicsParams(chainId), bondCalculatorParams(chainId), uniswapV2PairParams(address, chainId), erc20Params(address, chainId). chainId widened to `number` so wagmi's simulate/write/wait overloads accept it against the workspace's non-const chains tuple.

apps/bond/components/BondingProducts/Bonding/BondingList/useBondingList.jsx
- getLastIDFRequest -> readContract(tokenomicsParams, 'getLastIDF').
- getLpTokenDetails: token0/token1 reads now run in parallel via Promise.all + readContract on uniswapV2PairParams; symbol read via erc20Params. Net 3 sequential awaits -> 1 Promise.all + 1 await.
- useProductListRequest: getProducts read via readContract(depositoryParams).

apps/bond/components/BondingProducts/Bonding/Deposit/useDeposit.jsx
- hasSufficientTokenRequest / getLpBalanceRequest: readContract reads. hasSufficientToken now uses bigint comparison via BigInt(response) instead of relying on web3.js's string coercion.
- approveRequest / depositRequest: simulateContract + writeContract + waitForTransactionReceipt. Drops the local sendTransaction + getEstimatedGasLimit dance.

apps/bond/components/BondingProducts/requests.js + MyBonds/requests.js
- Near-identical files (cross-file duplication is pre-existing); both migrated to the same shape.
- mapUserBonds / getBonds / getBondStatus reads -> readContract loops via Promise.all (was sequential .call() pushes onto an array).
- redeemRequest -> simulateContract + writeContract + waitForTransactionReceipt.
- epoch reads (epochCounter, mapEpochTokenomics, epochLen) -> readContract; bigint -> Number() at the boundary as needed. mapEpochTokenomics epoch arg now wrapped in BigInt() (uint256).

apps/bond/common-util/Login/LoginV2.jsx
- Drops `import Web3 from 'web3'` and `const wProvider = new Web3(...)`.
- Removes `window.WEB3_PROVIDER = wProvider` — verified by repo-wide grep that nothing reads it. Keeps `window.MODAL_PROVIDER`, which libs/util-functions/getModalProvider still reads for the legacy gnosis-safe polling path.

Eliminates the last 2 of 9 source-file web3.js imports across apps/bond/. After this lands, only marketplace remains (1 file). The `web3` direct dep can be considered for removal once marketplace is migrated.

Verification on this branch (rebased onto current umbrella)
- yarn nx build bond: green (213s)
- npx eslint on all changed files: 0 errors, 3 pre-existing react-hooks/exhaustive-deps warnings in LoginV2.jsx (unrelated)
- yarn supply-chain: green (0 allowlisted, no unlisted high/critical)
- yarn nx test bond fails on a pre-existing nx config bug (project.json references apps/bond/jest.config.ts but the actual file is jest.config.js) — unrelated to this PR. Same single existing spec (apps/bond/specs/index.spec.tsx) was already failing on main.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## Fixes

<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Supply-chain checklist

_Only if this PR changes deps, workflows, or `.supply-chain/`. Full policy: [SUPPLY-CHAIN-SECURITY.md](../SUPPLY-CHAIN-SECURITY.md)._

- [ ] `yarn supply-chain` passes locally.
- [ ] Any new/bumped dep is exact-pinned, ≥7 days old (or has a CVE), and reviewed.
- [ ] Any new GitHub Action is SHA-pinned.
