### PR TITLE
chore(security): bump protobufjs resolution 7.5.6 → 7.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "cipher-base": "1.0.5",
     "elliptic": "6.6.1",
     "pbkdf2": "3.1.3",
-    "protobufjs": "7.5.6",
+    "protobufjs": "7.5.8",
     "rc-util": "5.44.4",
     "sha.js": "2.4.12",
     "@remix-run/router": "1.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17295,10 +17295,10 @@ property-information@^7.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
-protobufjs@7.2.6, protobufjs@7.5.6, protobufjs@^6.10.2:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.6.tgz#11af832ebc4b4326f658a5b1308e6141eb57edfd"
-  integrity sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==
+protobufjs@7.2.6, protobufjs@7.5.8, protobufjs@^6.10.2:
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.8.tgz#51b153a06da6e47153a1aa6800cb1253bc502436"
+  integrity sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Summary

Closes Dependabot alert **#362** (GHSA-jggg-4jg4-v7c6, medium) — protobufjs DoS via unbounded recursive JSON descriptor expansion. Vulnerable range `<= 7.5.7`, first patched `7.5.8`.

The `resolutions` block already pinned protobufjs at `7.5.6`; this just moves it to the patched `7.5.8`. Patch bump within the 7.5.x line — no API changes.

## Test plan

Verified locally on Node 22.18.0:

- [x] `yarn install` — clean; protobufjs resolves to 7.5.8 (single entry, no duplicates)
- [x] `yarn supply-chain` — all 3 gates pass
- [x] `yarn nx test {build,contribute,govern,launch}` — pass
- [x] `yarn nx run-many --target=build --projects=<all 9 apps>` — all 9 build successfully

This is the last fixable alert. After it merges, only 3 `tolerable_risk` alerts remain (no upstream patch): `@stablelib/ed25519` #270, `elliptic` #167, `@tootallnate/once` #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)