### PR TITLE
fix(security): resolve CodeQL DOMXSS alerts on dynamic href

### DIFF
--- a/apps/bond/components/BondingProducts/Bonding/BondingList/BondingList.jsx
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/BondingList.jsx
@@ -31,7 +31,7 @@ import { useHelpers } from 'common-util/hooks/useHelpers';
 
 import { Deposit } from '../Deposit/Deposit';
 import { useProducts } from './useBondingList';
-import { getLpTokenWithDiscount } from './utils';
+import { getEtherscanReadContractLink, getLpTokenWithDiscount } from './utils';
 
 const { Text } = Typography;
 
@@ -63,6 +63,9 @@ const getColumns = (onClick, isActive, acc, depositoryAddress, hideEmptyProducts
     if (type === VM_TYPE.SVM) return 'Solana';
     return CHAIN_NAMES[type];
   };
+  // Validated once so the (dynamic) depository address is sanitized before it
+  // reaches any anchor `href` below (guards against DOM-based XSS).
+  const depositoryReadLink = getEtherscanReadContractLink(depositoryAddress);
   const columns = [
     {
       title: 'ID',
@@ -141,15 +144,14 @@ const getColumns = (onClick, isActive, acc, depositoryAddress, hideEmptyProducts
       dataIndex: 'roundedDiscountedOlasPerLpToken',
       key: 'roundedDiscountedOlasPerLpToken',
       width: 180,
-      render: (x) => (
-        <a
-          href={`https://etherscan.io/address/${depositoryAddress}#readContract#F10`}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {x}
-        </a>
-      ),
+      render: (x) =>
+        depositoryReadLink ? (
+          <a href={depositoryReadLink} rel="noopener noreferrer" target="_blank">
+            {x}
+          </a>
+        ) : (
+          x
+        ),
     },
     {
       title: getTitle(
@@ -177,15 +179,14 @@ const getColumns = (onClick, isActive, acc, depositoryAddress, hideEmptyProducts
       dataIndex: 'vesting',
       key: 'vesting',
       width: 120,
-      render: (seconds) => (
-        <a
-          href={`https://etherscan.io/address/${depositoryAddress}#readContract#F10`}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {`${seconds / 86400} days`}
-        </a>
-      ),
+      render: (seconds) =>
+        depositoryReadLink ? (
+          <a href={depositoryReadLink} rel="noopener noreferrer" target="_blank">
+            {`${seconds / 86400} days`}
+          </a>
+        ) : (
+          `${seconds / 86400} days`
+        ),
     },
     {
       title: getTitle('OLAS Supply', 'Remaining OLAS supply reserved for this bonding product'),
@@ -196,13 +197,13 @@ const getColumns = (onClick, isActive, acc, depositoryAddress, hideEmptyProducts
         const supplyLeftInPercent = isNaN(row.supplyLeft) ? 0 : round(row.supplyLeft * 100, 0);
         return (
           <>
-            <a
-              href={`https://etherscan.io/address/${depositoryAddress}#readContract#F10`}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {round(parseToEth(x), 2)}
-            </a>
+            {depositoryReadLink ? (
+              <a href={depositoryReadLink} rel="noopener noreferrer" target="_blank">
+                {round(parseToEth(x), 2)}
+              </a>
+            ) : (
+              round(parseToEth(x), 2)
+            )}
             &nbsp;&nbsp;
             <Tag color={supplyLeftInPercent < 6 ? COLOR.GREY_2 : COLOR.PRIMARY}>
               {`${supplyLeftInPercent}%`}

--- a/apps/bond/components/BondingProducts/Bonding/BondingList/utils.js
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/utils.js
@@ -11,6 +11,19 @@ import { ADDRESS_ZERO } from 'common-util/constants/numbers';
 import { DEX } from 'common-util/enums';
 import { AUTONOLAS_GRAPH_CLIENTS } from 'common-util/graphql/clients';
 
+/**
+ * Builds an Etherscan link to a contract's read methods.
+ *
+ * Validates and checksums the address first so that only a well-formed `0x…`
+ * address can ever be interpolated into the URL. This guards against DOM-based
+ * XSS where a dynamic value flows into an anchor `href`. Returns `null` for an
+ * invalid/missing address so callers can fall back to plain text.
+ */
+export const getEtherscanReadContractLink = (address, fragment = 'readContract#F10') => {
+  if (!ethers.isAddress(address)) return null;
+  return `https://etherscan.io/address/${ethers.getAddress(address)}#${fragment}`;
+};
+
 export const getProductValueFromEvent = (product, events, keyName) => {
   if ((events || []).length === 0) {
     return product[keyName];

--- a/apps/bond/components/BondingProducts/Bonding/BondingList/utils.js
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/utils.js
@@ -21,7 +21,7 @@ import { AUTONOLAS_GRAPH_CLIENTS } from 'common-util/graphql/clients';
  */
 export const getEtherscanReadContractLink = (address, fragment = 'readContract#F10') => {
   if (!ethers.isAddress(address)) return null;
-  return `https://etherscan.io/address/${ethers.getAddress(address)}#${fragment}`;
+  return `https://etherscan.io/address/${encodeURIComponent(ethers.getAddress(address))}#${fragment}`;
 };
 
 export const getProductValueFromEvent = (product, events, keyName) => {

--- a/apps/bond/components/BondingProducts/Bonding/BondingList/utils.spec.js
+++ b/apps/bond/components/BondingProducts/Bonding/BondingList/utils.spec.js
@@ -1,0 +1,38 @@
+// utils.js transitively imports util-constants, which pulls in wagmi's ESM
+// chain exports that jest is not configured to transform. The helper under
+// test only depends on ethers, so stub the constant it consumes.
+jest.mock('libs/util-constants/src', () => ({ VM_TYPE: { SVM: 'svm', EVM: 'evm' } }));
+
+import { getEtherscanReadContractLink } from './utils';
+
+describe('getEtherscanReadContractLink', () => {
+  // Lower-cased input; getAddress should checksum it in the output.
+  const valid = '0x52908400098527886e0f7030069857d2e4169ee7';
+  const checksummed = '0x52908400098527886E0F7030069857D2E4169EE7';
+
+  it('builds a checksummed etherscan read link for a valid address', () => {
+    expect(getEtherscanReadContractLink(valid)).toBe(
+      `https://etherscan.io/address/${checksummed}#readContract#F10`,
+    );
+  });
+
+  it('honors a custom fragment', () => {
+    expect(getEtherscanReadContractLink(valid, 'readContract#F7')).toBe(
+      `https://etherscan.io/address/${checksummed}#readContract#F7`,
+    );
+  });
+
+  // Security-relevant: nothing that isn't a well-formed address can ever
+  // produce an href, so a javascript: payload or HTML-breakout string is
+  // rejected before it could reach the DOM.
+  it.each([
+    null,
+    undefined,
+    '',
+    'not-an-address',
+    'javascript:alert(1)',
+    `${valid}"><script>alert(1)</script>`,
+  ])('returns null for invalid/malicious input: %s', (bad) => {
+    expect(getEtherscanReadContractLink(bad)).toBeNull();
+  });
+});

--- a/apps/bond/jest.setup.js
+++ b/apps/bond/jest.setup.js
@@ -1,2 +1,7 @@
+import { TextDecoder, TextEncoder } from 'util';
+
 import '@testing-library/jest-dom/jest-globals';
 import '@testing-library/jest-dom';
+
+// jsdom does not expose TextEncoder/TextDecoder, which viem requires on import.
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/apps/contribute/components/Staking/StakingStepper.tsx
+++ b/apps/contribute/components/Staking/StakingStepper.tsx
@@ -278,13 +278,19 @@ const SetUpAndStake = ({
 
   if (multisig) {
     const selectedContract = contract ? STAKING_CONTRACTS_DETAILS[contract] : null;
+    // Validate + checksum the address so only a well-formed `0x…` address can
+    // reach the anchor `href` (guards against DOM-based XSS).
+    const contractLink =
+      contract && isAddress(contract)
+        ? `${GOVERN_APP_URL}/contracts/${getAddress(contract)}`
+        : null;
     return (
       <Flex vertical gap={8}>
         <Text type="secondary">
           Your staking contract:{' '}
           {isServiceInfoLoading && !selectedContract && <Skeleton.Input size="small" active />}
-          {selectedContract && (
-            <a href={`${GOVERN_APP_URL}/contracts/${contract}`} target="_blank">
+          {selectedContract && contractLink && (
+            <a href={contractLink} target="_blank">
               {selectedContract.name} ↗
             </a>
           )}

--- a/apps/contribute/components/Staking/StakingStepper.tsx
+++ b/apps/contribute/components/Staking/StakingStepper.tsx
@@ -282,7 +282,7 @@ const SetUpAndStake = ({
     // reach the anchor `href` (guards against DOM-based XSS).
     const contractLink =
       contract && isAddress(contract)
-        ? `${GOVERN_APP_URL}/contracts/${getAddress(contract)}`
+        ? `${GOVERN_APP_URL}/contracts/${encodeURIComponent(getAddress(contract))}`
         : null;
     return (
       <Flex vertical gap={8}>


### PR DESCRIPTION
## What

Resolves the 4 open CodeQL **`javascript/DOMXSS`** code-scanning alerts where a dynamic value flowed into an anchor `href`:

| Alert | File | Sink |
|-------|------|------|
| #1–3 | `apps/bond/.../BondingList/BondingList.jsx` | `depositoryAddress` (3 sinks) |
| #4 | `apps/contribute/.../Staking/StakingStepper.tsx` | staking contract address |

## Why

The values are Ethereum contract addresses sourced from config maps (`ADDRESSES[chainId]`) and a fixed `STAKING_CONTRACTS` list — not arbitrary user input — so these are effectively false positives. But rather than dismiss them, this PR adds genuine validation that also breaks CodeQL's taint flow.

## How

- **Validate + checksum** each address via `isAddress` + `getAddress` before it reaches the `href`; invalid/missing addresses fall back to plain text. New shared helper `getEtherscanReadContractLink` in the bond `utils.js`.
- **`encodeURIComponent`** on the already-checksummed address — a runtime no-op for a `0x…` address, but a sanitizer CodeQL recognizes explicitly so the alerts reliably close.

## Notes

- Split out from PR #404 (protobufjs bump) — unrelated change, kept separate.
- Lint passes for both apps.
- Draft pending review of whether to keep the `encodeURIComponent` belt-and-suspenders commit (`8275768c5`) or rely on validation alone (`3f317dc5d`).