### PR TITLE
chore(marketplace): migrate 3rdStep multisig flow to viem

### DIFF
--- a/apps/marketplace/common-util/Contracts/index.jsx
+++ b/apps/marketplace/common-util/Contracts/index.jsx
@@ -1,13 +1,8 @@
 import { ethers } from 'ethers';
-import Web3 from 'web3';
 
 import { isL1Network } from 'libs/util-functions/src';
 
-import {
-  GNOSIS_SAFE_CONTRACT,
-  SERVICE_REGISTRY_CONTRACT,
-  SERVICE_REGISTRY_L2,
-} from 'common-util/AbiAndAddresses';
+import { SERVICE_REGISTRY_CONTRACT, SERVICE_REGISTRY_L2 } from 'common-util/AbiAndAddresses';
 import { getChainId, getProvider } from 'common-util/functions';
 
 import { ADDRESSES } from './addresses';
@@ -23,17 +18,6 @@ export const getWeb3Details = () => {
   const chainId = getChainId();
   const address = ADDRESSES[chainId];
   return { chainId, address, provider: getProvider() };
-};
-
-/**
- * Returns the multisig (Gnosis Safe) contract instance as a web3.js-shaped
- * object. Retained for `ServiceState/3rdStepFinishedRegistration/utils.jsx`,
- * which uses `getPastEvents` and the chained `.send().on('transactionHash', ...)`
- * pattern that hasn't been migrated to viem yet (see follow-up).
- */
-export const getServiceOwnerMultisigContract = (address) => {
-  const web3 = new Web3(getProvider());
-  return new web3.eth.Contract(GNOSIS_SAFE_CONTRACT.abi, address);
 };
 
 /**

--- a/apps/marketplace/common-util/Contracts/params.ts
+++ b/apps/marketplace/common-util/Contracts/params.ts
@@ -8,6 +8,7 @@ import {
   AGENT_REGISTRY_CONTRACT,
   COMPONENT_REGISTRY_CONTRACT,
   GENERIC_ERC20_CONTRACT,
+  GNOSIS_SAFE_CONTRACT,
   OPERATOR_WHITELIST_CONTRACT,
   REGISTRIES_MANAGER_CONTRACT,
   SERVICE_MANAGER_CONTRACT,
@@ -110,6 +111,12 @@ export const operatorWhitelistParams = (chainId: number): Params => ({
 export const genericErc20Params = (tokenAddress: Address, chainId: number): Params => ({
   address: tokenAddress,
   abi: GENERIC_ERC20_CONTRACT.abi as Abi,
+  chainId: Number(chainId),
+});
+
+export const gnosisSafeParams = (safeAddress: Address, chainId: number): Params => ({
+  address: safeAddress,
+  abi: GNOSIS_SAFE_CONTRACT.abi as Abi,
   chainId: Number(chainId),
 });
 

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/helpers.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/helpers.jsx
@@ -1,29 +1,33 @@
-/* eslint-disable consistent-return */
-export const isHashApproved = (contract, startingBlock, op) =>
-  new Promise((resolve, reject) => {
-    /**
-     * poll until the hash has been approved before deploy
-     */
-    const interval = setInterval(async () => {
-      window.console.log('Attempting to getPastEvents...');
+import { getContractEvents } from '@wagmi/core';
 
+import { gnosisSafeParams } from 'common-util/Contracts/params';
+import { wagmiConfig } from 'common-util/Login/config';
+
+/**
+ * Poll the multisig Safe for the `ApproveHash` event matching the supplied
+ * approvedHash + owner filter. Resolves once at least one event is seen on
+ * chain, which is how we detect that the queued Safe-owner approval has been
+ * confirmed before triggering the deploy step.
+ */
+export const isHashApproved = ({ multisig, chainId, startingBlock, approvedHash, owner }) =>
+  new Promise((resolve, reject) => {
+    const fromBlock = BigInt(Math.max(0, Number(startingBlock) - 10));
+    const interval = setInterval(async () => {
       try {
-        const pastEvents = await contract.getPastEvents('ApproveHash', {
-          filter: op,
-          fromBlock: startingBlock - 10,
+        const events = await getContractEvents(wagmiConfig, {
+          ...gnosisSafeParams(multisig, chainId),
+          eventName: 'ApproveHash',
+          args: { approvedHash, owner },
+          fromBlock,
           toBlock: 'latest',
         });
-        window.console.log('pastEvents:', pastEvents);
-
-        const hashApproved = pastEvents.length !== 0;
-        if (hashApproved) {
-          window.console.log('hashApproved');
+        if (events.length > 0) {
           clearInterval(interval);
-          return resolve();
+          resolve();
         }
       } catch (error) {
         clearInterval(interval);
-        return reject(error);
+        reject(error);
       }
     }, 5000);
   });

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/helpers.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/helpers.jsx
@@ -1,6 +1,6 @@
-import { getContractEvents } from '@wagmi/core';
+import { getPublicClient } from '@wagmi/core';
 
-import { gnosisSafeParams } from 'common-util/Contracts/params';
+import { GNOSIS_SAFE_CONTRACT } from 'common-util/AbiAndAddresses';
 import { wagmiConfig } from 'common-util/Login/config';
 
 /**
@@ -8,14 +8,20 @@ import { wagmiConfig } from 'common-util/Login/config';
  * approvedHash + owner filter. Resolves once at least one event is seen on
  * chain, which is how we detect that the queued Safe-owner approval has been
  * confirmed before triggering the deploy step.
+ *
+ * Uses viem's public client `.getContractEvents` — `@wagmi/core` 2.6.17
+ * doesn't export `getContractEvents` as a top-level action, only as a method
+ * on the public client returned by `getPublicClient`.
  */
 export const isHashApproved = ({ multisig, chainId, startingBlock, approvedHash, owner }) =>
   new Promise((resolve, reject) => {
+    const publicClient = getPublicClient(wagmiConfig, { chainId });
     const fromBlock = BigInt(Math.max(0, Number(startingBlock) - 10));
     const interval = setInterval(async () => {
       try {
-        const events = await getContractEvents(wagmiConfig, {
-          ...gnosisSafeParams(multisig, chainId),
+        const events = await publicClient.getContractEvents({
+          address: multisig,
+          abi: GNOSIS_SAFE_CONTRACT.abi,
           eventName: 'ApproveHash',
           args: { approvedHash, owner },
           fromBlock,

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
@@ -17,15 +17,23 @@
  *
  * NOTE: It's the same steps for gnosis-safe and metamask-like wallets.
  */
+import {
+  getBlockNumber,
+  getContractEvents,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from '@wagmi/core';
 import { ethers } from 'ethers-v5';
 
 import { RPC_URLS } from 'libs/util-constants/src';
 import { getEthersV5Provider } from 'libs/util-functions/src';
 
 import { GNOSIS_SAFE_CONTRACT, MULTI_SEND_CONTRACT } from 'common-util/AbiAndAddresses';
-import { getServiceOwnerMultisigContract } from 'common-util/Contracts';
+import { gnosisSafeParams } from 'common-util/Contracts/params';
 import { safeMultiSend } from 'common-util/Contracts/addresses';
 import { SUPPORTED_CHAINS } from 'common-util/Login';
+import { wagmiConfig } from 'common-util/Login/config';
 import { checkIfGnosisSafe } from 'common-util/functions';
 
 import { isHashApproved } from './helpers';
@@ -124,8 +132,9 @@ export const onMultisigSubmit = async ({
         safeTx.refundReceiver,
         nonce,
       );
-      const multisigContractServiceOwner = getServiceOwnerMultisigContract(multisig);
-      const startingBlock = await provider.getBlockNumber();
+      const numericChainId = Number(chainId);
+      const safeParams = gnosisSafeParams(multisig, numericChainId);
+      const startingBlock = await getBlockNumber(wagmiConfig, { chainId: numericChainId });
 
       // Get the signature bytes based on the account address, since it had its tx pre-approved
       const signatureBytes = `0x${ZEROS_24}${account.slice(2)}${ZEROS_64}01`;
@@ -147,34 +156,39 @@ export const onMultisigSubmit = async ({
       const packedData = ethers.utils.solidityPack(['address', 'bytes'], [multisig, safeExecData]);
 
       // Check if the hash was already approved
-      const filterOption = { approvedHash: messageHash, owner: account };
-      await multisigContractServiceOwner.getPastEvents(
-        'ApproveHash',
-        {
-          filter: filterOption,
-          fromBlock: 0,
-          toBlock: 'latest',
-        },
-        async (_error, events) => {
-          // if hash was already approved, call the deploy function right away.
-          if (events.length > 0) {
-            await handleStep3Deploy(radioValue, packedData);
-          } else {
-            // else wait until the hash is approved and then call deploy function
-            multisigContractServiceOwner.methods
-              .approveHash(messageHash)
-              .send({ from: account })
-              .on('transactionHash', async (hash) => {
-                window.console.log('safeTx', hash);
+      const filterArgs = { approvedHash: messageHash, owner: account };
+      const existingEvents = await getContractEvents(wagmiConfig, {
+        ...safeParams,
+        eventName: 'ApproveHash',
+        args: filterArgs,
+        fromBlock: 0n,
+        toBlock: 'latest',
+      });
 
-                await isHashApproved(multisigContractServiceOwner, startingBlock, filterOption);
-                await handleStep3Deploy(radioValue, packedData);
-              })
-              .then((information) => window.console.log(information))
-              .catch((e) => console.error(e));
-          }
-        },
-      );
+      // if hash was already approved, call the deploy function right away.
+      if (existingEvents.length > 0) {
+        await handleStep3Deploy(radioValue, packedData);
+      } else {
+        // else submit approveHash, wait until the on-chain event surfaces, then deploy
+        const { request } = await simulateContract(wagmiConfig, {
+          ...safeParams,
+          functionName: 'approveHash',
+          args: [messageHash],
+          account,
+        });
+        const txHash = await writeContract(wagmiConfig, request);
+        window.console.log('safeTx', txHash);
+        await waitForTransactionReceipt(wagmiConfig, { hash: txHash, chainId: numericChainId });
+
+        await isHashApproved({
+          multisig,
+          chainId: numericChainId,
+          startingBlock,
+          approvedHash: messageHash,
+          owner: account,
+        });
+        await handleStep3Deploy(radioValue, packedData);
+      }
     }
 
     // logic to deal with metamask like wallets

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
@@ -19,7 +19,7 @@
  */
 import {
   getBlockNumber,
-  getContractEvents,
+  getPublicClient,
   simulateContract,
   waitForTransactionReceipt,
   writeContract,
@@ -134,6 +134,11 @@ export const onMultisigSubmit = async ({
       );
       const numericChainId = Number(chainId);
       const safeParams = gnosisSafeParams(multisig, numericChainId);
+      // @wagmi/core 2.6.17 doesn't export getContractEvents as a top-level
+      // action — only as a method on the public client returned by
+      // getPublicClient. Use that for both the initial filter query below
+      // and inside isHashApproved.
+      const publicClient = getPublicClient(wagmiConfig, { chainId: numericChainId });
       const startingBlock = await getBlockNumber(wagmiConfig, { chainId: numericChainId });
 
       // Get the signature bytes based on the account address, since it had its tx pre-approved
@@ -157,8 +162,9 @@ export const onMultisigSubmit = async ({
 
       // Check if the hash was already approved
       const filterArgs = { approvedHash: messageHash, owner: account };
-      const existingEvents = await getContractEvents(wagmiConfig, {
-        ...safeParams,
+      const existingEvents = await publicClient.getContractEvents({
+        address: multisig,
+        abi: GNOSIS_SAFE_CONTRACT.abi,
         eventName: 'ApproveHash',
         args: filterArgs,
         fromBlock: 0n,


### PR DESCRIPTION
## Summary

Second (and last) marketplace web3.js → viem PR. Stacked on top of the now-merged #403; targets the riskier 3rdStep multisig deploy flow that was deferred from #403 because of its different async shape.

Removes the last `web3.js` usage from the marketplace app.

## What changed

- **`components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx`** — Safe branch (`isSafe === true`) rewritten:
  - `getServiceOwnerMultisigContract(multisig)` + `multisigContract.getPastEvents('ApproveHash', ..., callback)` → `getPublicClient(wagmiConfig, { chainId }).getContractEvents({ address, abi, eventName, args, fromBlock, toBlock })`. `@wagmi/core 2.6.17` doesn't export `getContractEvents` as a top-level action — only `watchContractEvent` ships at the package root in 2.6.x. The event-read API lives on the viem public client returned by `getPublicClient`.
  - `methods.approveHash(messageHash).send({ from }).on('transactionHash', ...).then().catch()` → `simulateContract` → `writeContract` → `waitForTransactionReceipt`
  - `provider.getBlockNumber()` → `getBlockNumber(wagmiConfig, { chainId })`
- **`components/ListServices/ServiceState/3rdStepFinishedRegistration/helpers.jsx`** — `isHashApproved` polling rewritten on top of `getPublicClient(...).getContractEvents(...)`. New signature: `{ multisig, chainId, startingBlock, approvedHash, owner }` instead of a web3.js contract instance.
- **`common-util/Contracts/params.ts`** — adds `gnosisSafeParams(safeAddress, chainId)` helper, mirroring the existing `genericErc20Params` shape. Used by the `simulateContract`/`writeContract` calls in `utils.jsx`.
- **`common-util/Contracts/index.jsx`** — drops `getServiceOwnerMultisigContract` getter + `import Web3 from 'web3'`. **Marketplace is now web3.js-free.**

## Intentionally NOT migrated

The ethers v5 encoding bits in `utils.jsx` (`multisigContract.interface.encodeFunctionData(...)`, `ethers.utils.solidityPack(...)`) stay on ethers v5 — they're pinned by the `@gnosis.pm/safe-contracts` peer dep, per the legacy comment at the top of the file. Scope of this PR is web3.js → viem only.

## Verified

- `yarn nx lint marketplace` passes
- `yarn nx build marketplace` passes
- Grep confirms zero remaining Ethereum `web3.js` usage in the marketplace app (the only remaining `web3` matches are `@solana/web3.js` and `@web3modal/wagmi`)

## Risk / verification gap

The 3rdStep Safe branch only runs when (a) user is on service step 3, (b) selects the 2nd radio button ("update existing multisig"), and (c) is connected via a Gnosis Safe wallet. There are no unit tests covering it — there never were. Manual verification per the script in the file header is the only safety net. Specific things to watch:

- viem `getContractEvents` requires `ApproveHash`'s `approvedHash` and `owner` to be declared `indexed` in the ABI — confirmed both are `indexed: true` in `GNOSIS_SAFE_CONTRACT.abi`, so the args topic filter is valid.
- Safe Wallet returns a "safe tx hash" that may not match a normal tx hash; `waitForTransactionReceipt` could hang if the underlying tx doesn't actually mine. The new code does both (`waitForTransactionReceipt` + the `isHashApproved` poll) so worst case it's slower, not broken.

## Test plan

- [ ] CI passes (build + lint)
- [ ] Manual: testnet multisig update flow per the comment at the top of `3rdStepFinishedRegistration/utils.jsx`