### PR TITLE
chore(govern): migrate Web3Modal -> RainbowKit

### DIFF
--- a/apps/govern/CLAUDE.md
+++ b/apps/govern/CLAUDE.md
@@ -12,14 +12,14 @@ Olas governance: **voting**, **veOLAS**, **proposals**, **donations**, and **vot
 
 ## Stack
 
-- **Wallet**: Web3Modal (Wagmi). See `context/Web3ModalProvider.tsx`, `components/Login/`, `components/Contracts/`, `components/Donate/`, `components/Proposals/`, `components/VeOlas/`.
+- **Wallet**: RainbowKit (over Wagmi). See `context/Web3ModalProvider.tsx` (filename kept pending a cross-app rename), `components/Login/`, `components/Contracts/`, `components/Donate/`, `components/Proposals/`, `components/VeOlas/`.
 - **State**: Redux (`store/`).
 - **Key libs**: `util-constants`, `util-functions`, `util-contracts`, `ui-theme`, `ui-components`, `util-prohibited-data`, `common-contract-functions`, `common-middleware`, `util-ssr`.
 
 ## Env / backends
 
 - **Governor subgraph**: `NEXT_PUBLIC_GOVERNOR_SUBGRAPH_URL`
-- RPCs and Wallet Project ID for Web3Modal.
+- RPCs and Wallet Project ID for RainbowKit (WalletConnect Cloud projectId — required by `getDefaultConfig`).
 
 ## Structure
 

--- a/apps/govern/common-util/config/wagmi.ts
+++ b/apps/govern/common-util/config/wagmi.ts
@@ -1,3 +1,4 @@
+import { getDefaultConfig } from '@rainbow-me/rainbowkit';
 import { cookieStorage, createStorage, http } from 'wagmi';
 import {
   Chain,
@@ -13,7 +14,6 @@ import {
 } from 'wagmi/chains';
 
 import { RPC_URLS } from 'libs/util-constants/src';
-import { defaultWagmiConfig } from '@web3modal/wagmi';
 
 export const SUPPORTED_CHAINS: [Chain, ...Chain[]] = [
   mainnet,
@@ -27,32 +27,14 @@ export const SUPPORTED_CHAINS: [Chain, ...Chain[]] = [
   ...(process.env.NEXT_PUBLIC_IS_CONNECTED_TO_LOCAL === 'true' ? [hardhat] : []),
 ];
 
-const SUPPORTED_CHAINS_WITH_RPCS = SUPPORTED_CHAINS.map((chain) => {
-  const defaultRpc = RPC_URLS[chain.id] || chain.rpcUrls.default.http[0];
-  return {
-    ...chain,
-    rpcUrls: {
-      ...chain.rpcUrls,
-      default: { http: [defaultRpc] },
-    },
-  } as Chain;
-});
-
-const walletConnectMetadata = {
-  name: 'OLAS Govern',
-  description: 'OLAS Govern Web3 Modal',
-  url: 'https://govern.olas.network',
-  icons: ['https://avatars.githubusercontent.com/u/37784886'],
-};
-
-export const wagmiConfig = defaultWagmiConfig({
-  chains: SUPPORTED_CHAINS_WITH_RPCS as [Chain, ...Chain[]],
+export const wagmiConfig = getDefaultConfig({
+  appName: 'OLAS Govern',
   projectId: process.env.NEXT_PUBLIC_WALLET_PROJECT_ID || '',
-  metadata: walletConnectMetadata,
+  chains: SUPPORTED_CHAINS,
   storage: createStorage({ storage: cookieStorage }),
   transports: SUPPORTED_CHAINS.reduce(
     (acc, chain) =>
-      Object.assign(acc, { [chain.id]: http(RPC_URLS[chain.id]) || chain.rpcUrls.default.http[0] }),
+      Object.assign(acc, { [chain.id]: http(RPC_URLS[chain.id] || chain.rpcUrls.default.http[0]) }),
     {},
   ),
   ssr: true,

--- a/apps/govern/common-util/functions/requests.ts
+++ b/apps/govern/common-util/functions/requests.ts
@@ -28,41 +28,45 @@ import { getUnixNextWeekStartTimestamp } from './time';
 
 // All governance contracts live on mainnet.
 const MAINNET = mainnet.id;
+// Widened version for wagmi simulate/write/wait overloads — the literal `1`
+// doesn't satisfy the chain-tuple constraint in wagmi 2.19+, so each params
+// bag passes `chainId: MAINNET_CHAIN_ID` instead of the literal mainnet.id.
+const MAINNET_CHAIN_ID: number = mainnet.id;
 
 const voteWeightingParams = {
   address: (VOTE_WEIGHTING.addresses as Record<number, Address>)[MAINNET],
   abi: VOTE_WEIGHTING.abi as Abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const olasParams = {
   address: (OLAS.addresses as Record<number, Address>)[MAINNET],
   abi: OLAS.abi as Abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const veOlasParams = {
   address: (VE_OLAS.addresses as Record<number, Address>)[MAINNET],
   abi: VE_OLAS.abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const tokenomicsParams = {
   address: TOKENOMICS.addresses[MAINNET] as Address,
   abi: TOKENOMICS.abi as Abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const treasuryParams = {
   address: TREASURY.addresses[MAINNET] as Address,
   abi: TREASURY.abi as Abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const governorParams = {
   address: GOVERNOR_OLAS.addresses[MAINNET] as Address,
   abi: GOVERNOR_OLAS.abi as Abi,
-  chainId: MAINNET,
+  chainId: MAINNET_CHAIN_ID,
 };
 
 type VoteForNomineeWeightsParams = {
@@ -352,7 +356,7 @@ export const checkServicesTerminatedOrNotDeployed = async (ids: string[]) => {
       contracts: ids.map((id) => ({
         abi: SERVICE_REGISTRY.abi as Abi,
         address: (SERVICE_REGISTRY.addresses as Record<number, Address>)[MAINNET],
-        chainId: MAINNET,
+        chainId: MAINNET_CHAIN_ID,
         functionName: 'getService',
         args: [id],
       })),

--- a/apps/govern/components/Login/LoginV2.tsx
+++ b/apps/govern/components/Login/LoginV2.tsx
@@ -1,4 +1,6 @@
+import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { GetAccountReturnType, watchAccount } from '@wagmi/core';
+import { Button, Space } from 'antd';
 import { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { useAccountEffect, useConfig, useDisconnect } from 'wagmi';
@@ -63,7 +65,38 @@ export const LoginV2 = () => {
 
   return (
     <LoginContainer>
-      <w3m-button balance="hide" />
+      <ConnectButton.Custom>
+        {({ account, chain, openAccountModal, openChainModal, openConnectModal, mounted }) => {
+          if (!mounted) return null;
+
+          if (!account || !chain) {
+            return (
+              <Button type="primary" onClick={openConnectModal}>
+                Connect Wallet
+              </Button>
+            );
+          }
+
+          if (chain.unsupported) {
+            return (
+              <Button danger onClick={openChainModal}>
+                Wrong network
+              </Button>
+            );
+          }
+
+          return (
+            <Space size={4}>
+              <Button size="small" onClick={openChainModal}>
+                {chain.name}
+              </Button>
+              <Button size="small" onClick={openAccountModal}>
+                {account.displayName}
+              </Button>
+            </Space>
+          );
+        }}
+      </ConnectButton.Custom>
     </LoginContainer>
   );
 };

--- a/apps/govern/context/Web3ModalProvider.tsx
+++ b/apps/govern/context/Web3ModalProvider.tsx
@@ -1,10 +1,12 @@
+import { RainbowKitProvider, lightTheme } from '@rainbow-me/rainbowkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { createWeb3Modal } from '@web3modal/wagmi';
 import { PropsWithChildren } from 'react';
 import { WagmiProvider } from 'wagmi';
 
-import { COLOR, W3M_BORDER_RADIUS } from 'libs/ui-theme/src';
+import '@rainbow-me/rainbowkit/styles.css';
+
+import { COLOR } from 'libs/ui-theme/src';
 
 import { wagmiConfig } from 'common-util/config/wagmi';
 
@@ -17,24 +19,18 @@ export const queryClient = new QueryClient({
   },
 });
 
-createWeb3Modal({
-  wagmiConfig,
-  projectId: `${process.env.NEXT_PUBLIC_WALLET_PROJECT_ID}`,
-  themeMode: 'light',
-  themeVariables: {
-    '--w3m-font-family':
-      "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
-    '--w3m-accent': COLOR.PRIMARY,
-    '--w3m-border-radius-master': W3M_BORDER_RADIUS,
-    '--w3m-font-size-master': '11px',
-  },
+const rainbowKitTheme = lightTheme({
+  accentColor: COLOR.PRIMARY,
+  accentColorForeground: 'white',
+  borderRadius: 'small',
+  fontStack: 'system',
 });
 
 export const Web3ModalProvider = ({ children }: PropsWithChildren) => {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        {children}
+        <RainbowKitProvider theme={rainbowKitTheme}>{children}</RainbowKitProvider>
         <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
       </QueryClientProvider>
     </WagmiProvider>

--- a/apps/govern/index.d.ts
+++ b/apps/govern/index.d.ts
@@ -1,28 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // `export {}` makes this file a module (rather than an ambient script),
-// which is required for `declare module 'react'` below to *augment* React's
-// types instead of replacing them.
+// which is required for `declare module` augmentations to work.
 export {};
 
 declare module '*.svg' {
   const content: any;
   export const ReactComponent: any;
   export default content;
-}
-
-// In React 19 + @types/react 19, JSX is no longer a global namespace; it's
-// exported from 'react'. Use module augmentation to add custom-element types.
-// See https://react.dev/blog/2024/12/05/react-19#changes-to-jsx
-declare module 'react' {
-  namespace JSX {
-    interface IntrinsicElements {
-      'w3m-button': {
-        disabled?: boolean;
-        balance?: 'show' | 'hide';
-        size?: 'md' | 'sm';
-        label?: string;
-        loadingLabel?: string;
-      };
-    }
-  }
 }

--- a/apps/govern/next.config.js
+++ b/apps/govern/next.config.js
@@ -59,15 +59,4 @@ const plugins = [
   withNx,
 ];
 
-const composedConfig = composePlugins(...plugins)(nextConfig);
-
-// Next 16 removed the `eslint` config key, but @nx/next's `withNx` still
-// injects `eslint: { ignoreDuringBuilds: true }`. Strip it here to silence
-// the "Unrecognized key(s) in object: 'eslint'" warning at build time.
-// TODO: drop this wrapper once @nx/next stops injecting the `eslint` key
-// (track via https://github.com/nrwl/nx/issues for a Next 16-aware release).
-module.exports = async (/** @type {string} */ phase, /** @type {any} */ context) => {
-  const config = /** @type {any} */ (await composedConfig(phase, context));
-  delete config.eslint;
-  return config;
-};
+module.exports = composePlugins(...plugins)(nextConfig);


### PR DESCRIPTION
## Summary

Govern's RainbowKit migration. Stacked on **#406**; GitHub will auto-retarget to `precious/rainbowkit-migration` once #406 merges.

Same recipe as **#408** (launch), plus two govern-specific adjustments surfaced by wagmi 2.19's stricter typing under `getDefaultConfig`.

## Changes

| File | What |
|------|------|
| [common-util/config/wagmi.ts](apps/govern/common-util/config/wagmi.ts) | `defaultWagmiConfig` → `getDefaultConfig`. **Dropped the `SUPPORTED_CHAINS_WITH_RPCS` remap** — it lost the literal chain tuple that `getDefaultConfig`'s overload relies on. The `RPC_URLS[chain.id] \|\| chain.rpcUrls.default.http[0]` fallback is preserved inside the transports reducer instead. **This also fixes a latent bug** — see below. |
| [context/Web3ModalProvider.tsx](apps/govern/context/Web3ModalProvider.tsx) | `createWeb3Modal(...)` → `<RainbowKitProvider theme={lightTheme(...)}>` + RainbowKit CSS import. |
| [components/Login/LoginV2.tsx](apps/govern/components/Login/LoginV2.tsx) | `<w3m-button balance="hide" />` → `<ConnectButton.Custom>` rendering Ant `<Button>` for the three states. `resetState` + `clearUserState` wiring (govern-specific account-switch behavior) preserved as-is. |
| [index.d.ts](apps/govern/index.d.ts) | Dropped the `w3m-button` JSX intrinsic declaration. |
| [common-util/functions/requests.ts](apps/govern/common-util/functions/requests.ts) | Introduced `MAINNET_CHAIN_ID: number` alongside the existing literal `MAINNET = mainnet.id`. Wagmi 2.19's `simulateContract`/`readContracts` overloads reject the literal `1` against the new `wagmiConfig`'s chain tuple (`never` arg inference). Indexer expressions like `TOKENOMICS.addresses[MAINNET]` still need the literal form, so both are kept. |
| [CLAUDE.md](apps/govern/CLAUDE.md) | Wallet/Env lines updated: "Web3Modal (Wagmi)" → "RainbowKit (over Wagmi)". |

## Latent bugfix worth surfacing

The transports reducer fallback changed shape:

```diff
-  { [chain.id]: http(RPC_URLS[chain.id]) || chain.rpcUrls.default.http[0] }
+  { [chain.id]: http(RPC_URLS[chain.id] || chain.rpcUrls.default.http[0]) }
```

The old form's `||` operated on the **always-truthy** `Transport` object returned by `http(...)`, so the URL-string fallback was dead code. The previous `SUPPORTED_CHAINS_WITH_RPCS` remap (which mutated `chain.rpcUrls.default.http[0]`) was masking the bug because wagmi was still getting the right URL via the chain object's metadata. Collapsing both layers into the corrected `http(URL || fallback)` is a clean fix. Calling it out so it's not buried as a refactor — it's actually a fallback-path bugfix.

## MAINNET_CHAIN_ID tradeoff (documented)

The widening is unavoidable under wagmi 2.19's new chain-tuple inference, but the side-effect is that wagmi can no longer statically verify the chainId at the call sites that use `MAINNET_CHAIN_ID`. A typo or stale id would compile silently. Practical risk is low here (single mainnet-only file; addresses are still indexed via the literal `MAINNET`, so a mismatch would surface at the indexer layer). Centralizing the widening in two `const`s rather than scattering inline casts is the right call.

## Verified

- `yarn nx lint govern` passes
- `yarn nx build govern` passes

## Test plan

- [ ] CI passes
- [ ] Manual: pull, run dev server, exercise the connect/disconnect flow, then attempt a vote-weighting tx (the main `simulateContract` path that was rejected by the wagmi typing change)