### PR TITLE
chore(bond): migrate Web3Modal -> RainbowKit

### DIFF
--- a/apps/bond/CLAUDE.md
+++ b/apps/bond/CLAUDE.md
@@ -12,7 +12,7 @@ Bonding products for Olas: buy/sell OLAS and related tokens. Supports **EVM** (B
 
 ## Stack
 
-- **Wallet**: Yes. Web3Modal (EVM) + Solana wallet adapter. See `context/Web3ModalProvider.jsx`, `common-util/Login/`, `common-util/hooks/useSvmConnectivity.jsx`.
+- **Wallet**: Yes. RainbowKit (over Wagmi, EVM) + Solana wallet adapter. See `context/Web3ModalProvider.jsx` (filename kept pending a cross-app rename), `common-util/Login/`, `common-util/hooks/useSvmConnectivity.jsx`.
 - **State**: Redux (`store/`).
 - **Key libs**: `ui-components`, `ui-theme`, `util-functions`, `util-contracts`, `util-constants`, `util-prohibited-data`, `util-ssr`, `common-middleware`.
 

--- a/apps/bond/common-util/Login/LoginV2.jsx
+++ b/apps/bond/common-util/Login/LoginV2.jsx
@@ -1,4 +1,5 @@
-import { Grid } from 'antd';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { Button, Grid, Space } from 'antd';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -128,9 +129,43 @@ export const LoginV2 = ({ onConnect: onConnectCb, onDisconnect: onDisconnectCb }
 
   return (
     <LoginContainer>
-      <w3m-network-button />
-      &nbsp;&nbsp;
-      <w3m-button balance={screens.xs ? 'hide' : 'show'} />
+      <ConnectButton.Custom>
+        {({ account, chain, openAccountModal, openChainModal, openConnectModal, mounted }) => {
+          if (!mounted) return null;
+
+          if (!account || !chain) {
+            return (
+              <Button type="primary" onClick={openConnectModal}>
+                Connect Wallet
+              </Button>
+            );
+          }
+
+          if (chain.unsupported) {
+            return (
+              <Button danger onClick={openChainModal}>
+                Wrong network
+              </Button>
+            );
+          }
+
+          // On mobile (xs) the balance is hidden — matches the previous
+          // <w3m-button balance={screens.xs ? 'hide' : 'show'}> behavior.
+          const showBalance = !screens.xs && balance?.formatted;
+
+          return (
+            <Space size={8}>
+              <Button size="small" onClick={openChainModal}>
+                {chain.name}
+              </Button>
+              <Button size="small" onClick={openAccountModal}>
+                {showBalance ? `${Number(balance.formatted).toFixed(3)} ${balance.symbol} · ` : ''}
+                {account.displayName}
+              </Button>
+            </Space>
+          );
+        }}
+      </ConnectButton.Custom>
     </LoginContainer>
   );
 };

--- a/apps/bond/common-util/config/wagmi.js
+++ b/apps/bond/common-util/config/wagmi.js
@@ -1,38 +1,15 @@
-import { http, createConfig } from 'wagmi';
-import { mainnet, goerli } from 'wagmi/chains';
-import { safe, walletConnect, injected, coinbaseWallet } from 'wagmi/connectors';
+import { getDefaultConfig } from '@rainbow-me/rainbowkit';
+import { http } from 'wagmi';
+import { goerli, mainnet } from 'wagmi/chains';
+
 import { RPC_URLS } from 'common-util/constants/rpcs';
 
 export const SUPPORTED_CHAINS = [mainnet, goerli];
 
-const walletConnectMetadata = {
-  name: 'OLAS Bond',
-  description: 'OLAS Bond Web3 Modal',
-  url: 'https://bond.olas.network', // origin must match your domain & subdomain
-  icons: ['https://avatars.githubusercontent.com/u/37784886'],
-};
-
-export const wagmiConfig = createConfig({
-  autoConnect: true,
+export const wagmiConfig = getDefaultConfig({
+  appName: 'OLAS Bond',
+  projectId: process.env.NEXT_PUBLIC_WALLET_PROJECT_ID || '',
   chains: SUPPORTED_CHAINS,
-  options: {
-    rpc: SUPPORTED_CHAINS.reduce(
-      (acc, chain) => Object.assign(acc, { [chain.id]: RPC_URLS[chain.id] }),
-      {},
-    ),
-  },
-  connectors: [
-    injected(),
-    walletConnect({
-      projectId: process.env.NEXT_PUBLIC_WALLET_PROJECT_ID,
-      metadata: walletConnectMetadata,
-      showQrModal: false,
-    }),
-    safe(),
-    coinbaseWallet({
-      appName: 'OLAS Tokenomics',
-    }),
-  ],
   transports: SUPPORTED_CHAINS.reduce(
     (acc, chain) => Object.assign(acc, { [chain.id]: http(RPC_URLS[chain.id]) }),
     {},

--- a/apps/bond/context/Web3ModalProvider.jsx
+++ b/apps/bond/context/Web3ModalProvider.jsx
@@ -1,30 +1,28 @@
+import { RainbowKitProvider, lightTheme } from '@rainbow-me/rainbowkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createWeb3Modal } from '@web3modal/wagmi';
 import { WagmiProvider } from 'wagmi';
 
-import { COLOR, W3M_BORDER_RADIUS } from 'libs/ui-theme/src';
+import '@rainbow-me/rainbowkit/styles.css';
+
+import { COLOR } from 'libs/ui-theme/src';
 
 import { wagmiConfig } from 'common-util/config/wagmi';
 
 const queryClient = new QueryClient();
 
-createWeb3Modal({
-  wagmiConfig,
-  projectId: process.env.NEXT_PUBLIC_WALLET_PROJECT_ID,
-  themeMode: 'light',
-  themeVariables: {
-    '--w3m-font-family':
-      "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
-    '--w3m-accent': COLOR.PRIMARY,
-    '--w3m-border-radius-master': W3M_BORDER_RADIUS,
-    '--w3m-font-size-master': '11px',
-  },
+const rainbowKitTheme = lightTheme({
+  accentColor: COLOR.PRIMARY,
+  accentColorForeground: 'white',
+  borderRadius: 'small',
+  fontStack: 'system',
 });
 
 export default function Web3ModalProvider({ children }) {
   return (
     <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider theme={rainbowKitTheme}>{children}</RainbowKitProvider>
+      </QueryClientProvider>
     </WagmiProvider>
   );
 }

--- a/apps/bond/next.config.js
+++ b/apps/bond/next.config.js
@@ -45,15 +45,4 @@ const plugins = [
   withNx,
 ];
 
-const composedConfig = composePlugins(...plugins)(nextConfig);
-
-// Next 16 removed the `eslint` config key, but @nx/next's `withNx` still
-// injects `eslint: { ignoreDuringBuilds: true }`. Strip it here to silence
-// the "Unrecognized key(s) in object: 'eslint'" warning at build time.
-// TODO: drop this wrapper once @nx/next stops injecting the `eslint` key
-// (track via https://github.com/nrwl/nx/issues for a Next 16-aware release).
-module.exports = async (/** @type {string} */ phase, /** @type {any} */ context) => {
-  const config = /** @type {any} */ (await composedConfig(phase, context));
-  delete config.eslint;
-  return config;
-};
+module.exports = composePlugins(...plugins)(nextConfig);


### PR DESCRIPTION
## Summary

Final per-app PR in the in-scope batch (originally — marketplace's own RainbowKit migration ended up in a separate PR after #406 merged). Stacked on **#406**; auto-retargets to `precious/rainbowkit-migration` once #406 merges.

**Bond is the trickiest UI-wise** — a `.jsx` app with a responsive connect button that historically showed BOTH a network selector AND the account/balance button side-by-side (`<w3m-network-button>` + `<w3m-button balance={screens.xs ? 'hide' : 'show'}>`).

## Changes

| File | What |
|------|------|
| [common-util/config/wagmi.js](apps/bond/common-util/config/wagmi.js) | `createConfig` + raw connectors → `getDefaultConfig`. **Also a deliberate dead-config cleanup** — see below. |
| [context/Web3ModalProvider.jsx](apps/bond/context/Web3ModalProvider.jsx) | `createWeb3Modal(...)` → `<RainbowKitProvider theme={lightTheme(...)}>`. Standard recipe. |
| [common-util/Login/LoginV2.jsx](apps/bond/common-util/Login/LoginV2.jsx) | `<w3m-network-button>` + `<w3m-button balance={screens.xs ? 'hide' : 'show'} />` → a single `<ConnectButton.Custom>` rendering a chain pill + account pill via Ant `<Button>`. **Responsive behavior preserved**: on `xs` the balance is hidden, on larger breakpoints the formatted balance + symbol is prefixed to the account display. `watchAccount` / `setUserBalance` / `isAddressProhibited` wiring kept as-is. |
| [CLAUDE.md](apps/bond/CLAUDE.md) | Wallet stack line updated: "Web3Modal (EVM)" → "RainbowKit (over Wagmi, EVM)". Solana adapter half unchanged. |

**Net diff:** 3 files + CLAUDE.md.

**No `index.d.ts` change** — bond's `index.d.ts` didn't declare the `w3m-button` JSX intrinsic. LoginV2 is `.jsx`, so the web-component intrinsic was implicitly typed as `any`.

## Dead-config cleanup (worth surfacing)

Two wagmi-v1 leftovers removed from the config in the same edit, calling out so a future archaeologist knows they're deliberate dead-config removals, not behavior changes:

- **`autoConnect: true`** — wagmi v2's `WagmiProvider` has `reconnectOnMount` defaulting to `true`. The old flag isn't read by wagmi v2 and was a no-op for the entire time the app's been on v2.
- **`options.rpc: SUPPORTED_CHAINS.reduce(...)`** — wagmi v2 drives per-chain RPC URLs via the top-level `transports` map (which the config also sets), not `options.rpc`. Dead config.

## Verified

- `yarn nx lint bond` passes
- `yarn nx build bond` passes

## Test plan

- [ ] CI passes
- [ ] Manual: pull, run dev server, exercise connect flow on desktop AND mobile (resize browser) — confirm chain pill + balance-prefixed account pill appear at desktop width, balance hides at xs width
- [ ] Manual: page-refresh while connected — confirm session persists despite the `autoConnect: true` removal (wagmi v2's `reconnectOnMount` default handles it)