### PR TITLE
chore(security): pin js-cookie to 3.0.7 (CVE-2026-46625)

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "webpack": "5.104.1",
     "bn.js": "5.2.3",
     "ip-address": "10.1.1",
+    "js-cookie": "3.0.7",
     "@web3auth/no-modal/@metamask/sdk": "0.33.1",
     "@web3auth/no-modal/@metamask/sdk/@metamask/sdk-communication-layer": "0.33.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14838,10 +14838,10 @@ js-base64@^3.7.5:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
   integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
 
-js-cookie@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
-  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+js-cookie@3.0.1, js-cookie@3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
+  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
## What

Pins `js-cookie` to **3.0.7** via a `resolutions` entry, resolving Dependabot alert **#363**.

| | |
|---|---|
| **Advisory** | [GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j) / CVE-2026-46625 |
| **Severity** | High |
| **Vulnerable** | `js-cookie <= 3.0.5` |
| **Patched** | `3.0.7` |
| **Before** | single copy at `3.0.1` |
| **After** | single copy at `3.0.7` |

## Why

`js-cookie`'s `assign()` is vulnerable to a per-instance prototype hijack that enables cookie-attribute injection.

It is a **transitive** dependency only, via:
```
@web3auth/modal → @web3auth/no-modal → @segment/analytics-next → js-cookie
```
It is **not imported directly** anywhere in our source. `3.0.7` is a patch release on the same `3.0.x` line Segment requests, so it is a drop-in with no API change.

## Verification

- `yarn.lock` resolves `js-cookie` to a single `3.0.7` entry with a valid integrity hash; `3.0.1` is gone.
- `yarn lint:lockfile` → ✔ no issues
- `yarn audit:prod` → OK, no unlisted high/critical
- `yarn audit:install-hooks` → OK (11 allowlisted, **unchanged** — no new install hooks)
- No direct `js-cookie` usage in `apps/` or `libs/`.