### PR TITLE
chore(supply-chain): add non-blocking license allowlist gate

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -110,13 +110,12 @@ jobs:
         run: yarn audit:install-hooks
 
   license-check:
-    # Frontend mirror of the backend `liccheck` PARANOID gate (valory-xyz/tomte): every
-    # production dependency's license must be on the allowlist in
+    # Every production dependency's license must be on the allowlist in
     # .supply-chain/license-allowlist.json, or be an explicitly-reasoned exemption.
     # NON-BLOCKING PILOT: this job is deliberately NOT in the `all-checks-passed` aggregator
     # below, so it reports a red/green signal without gating merges. Promote it to required by
     # adding `license-check` to that job's `needs:` (+ branch protection) once the exemptions
-    # are signed off. See .plans/license-check-gate.md and SUPPLY-CHAIN-SECURITY.md.
+    # are signed off. See SUPPLY-CHAIN-SECURITY.md.
     name: License allowlist gate
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -109,6 +109,38 @@ jobs:
       - name: Diff install-hook surface against allowlist
         run: yarn audit:install-hooks
 
+  license-check:
+    # Frontend mirror of the backend `liccheck` PARANOID gate (valory-xyz/tomte): every
+    # production dependency's license must be on the allowlist in
+    # .supply-chain/license-allowlist.json, or be an explicitly-reasoned exemption.
+    # NON-BLOCKING PILOT: this job is deliberately NOT in the `all-checks-passed` aggregator
+    # below, so it reports a red/green signal without gating merges. Promote it to required by
+    # adding `license-check` to that job's `needs:` (+ branch protection) once the exemptions
+    # are signed off. See .plans/license-check-gate.md and SUPPLY-CHAIN-SECURITY.md.
+    name: License allowlist gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: '22.x'
+
+      - name: Pin Yarn via corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+
+      - name: Install dependencies (frozen)
+        run: yarn install --frozen-lockfile
+
+      - name: Check production dependency licenses
+        run: yarn license-check
+
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
@@ -141,6 +173,9 @@ jobs:
     # this aggregator covers in-workflow jobs only — Snyk and Vercel run in
     # separate workflows and are not gated through here. Mirrors the
     # pattern used in valory-xyz/agent-scan (.github/workflows/ci.yml).
+    #
+    # `license-check` is intentionally NOT listed below — it runs as a
+    # non-blocking pilot. Add it to `needs:` to make it a required gate.
     name: All checks passed
     needs: [audit, lockfile-lint, install-hooks, gitleaks]
     if: always()

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "License allowlist gate config — frontend mirror of the backend valory-xyz/tomte `liccheck` PARANOID gate. `allowedSpdx` mirrors tomte's authorized list (permissive + LGPL-2.1/MPL-2.0 weak copyleft). Anything not allowed — including UNKNOWN/Custom — fails unless its exact package NAME is in `exemptions` (version-agnostic). `exemptionPrefixes` is ONLY for platform-binary families whose name varies by OS/arch. Scope is production deps (what ships), matching tomte's frozen-runtime check. See scripts/license-check.mjs and .plans/license-check-gate.md.",
+  "_comment": "License allowlist gate config — frontend mirror of the backend valory-xyz/tomte `liccheck` PARANOID gate. `allowedSpdx` mirrors tomte's authorized list (permissive + LGPL-2.1/MPL-2.0 weak copyleft). A package whose license is not allowed — including UNKNOWN/Custom — fails, unless (1) it has a `licenseOverrides` correction, (2) its exact NAME is in `exemptions` (version-agnostic), or (3) its name matches an `exemptionPrefixes` entry. Scope is production deps (what ships). See scripts/license-check.mjs and .plans/license-check-gate.md.",
   "scope": "production",
   "allowedSpdx": [
     "MIT",
@@ -17,6 +17,7 @@
     "BlueOak-1.0.0",
     "CC0-1.0",
     "Unlicense",
+    "Public Domain",
     "WTFPL",
     "Zlib",
     "Python-2.0",
@@ -26,11 +27,26 @@
   ],
   "unauthorizedSpdx": ["GPL-2.0", "GPL-3.0", "LGPL-3.0", "MPL-1.1", "AGPL-3.0"],
 
+  "_licenseOverrides_comment": "Permissive packages the checker can't map to SPDX because package.json declares 'SEE LICENSE IN LICENSE' instead of an SPDX id. Corrected to their real license, each confirmed by reading the actual LICENSE file (the MIT text). These are CORRECTIONS, not policy exceptions — they pass the allowlist as MIT.",
+  "licenseOverrides": {
+    "@segment/facade": "MIT",
+    "@segment/isodate": "MIT",
+    "@segment/isodate-traverse": "MIT",
+    "new-date": "MIT"
+  },
+
   "exemptionPrefixes": [
+    {
+      "prefix": "@trezor/",
+      "spdx": "T-RSL / UNKNOWN (Trezor suite)",
+      "reason": "Trezor hardware-wallet SDK suite (~16 sub-packages), pulled via RainbowKit's Trezor connector. Single vendor with a uniform license stance: source-available T-RSL (e.g. @trezor/connect) or no SPDX field. `@trezor` is a publisher-controlled npm scope, so this prefix stays vendor-bounded while avoiding per-sub-package churn on version bumps.",
+      "parents": ["@rainbow-me/rainbowkit"],
+      "reviewDate": "2026-06-01"
+    },
     {
       "prefix": "@img/sharp-libvips-",
       "spdx": "LGPL-3.0-or-later",
-      "reason": "Platform-specific libvips binaries (image processing). Package name varies by OS/arch (@img/sharp-libvips-darwin-arm64 locally, @img/sharp-libvips-linux-x64 on CI), so a single exact name would be non-deterministic. LGPL-3.0 dynamically-linked native binary, not statically combined with our JS.",
+      "reason": "Platform-specific libvips binaries (image processing). Package name varies by OS/arch (@img/sharp-libvips-darwin-arm64 locally, @img/sharp-libvips-linux-x64 on CI), so a single exact name would be non-deterministic. `@img` is a publisher-controlled scope. LGPL-3.0 dynamically-linked native binary, not statically combined with our JS.",
       "parents": ["sharp"],
       "reviewDate": "2026-06-01"
     }
@@ -69,50 +85,6 @@
     },
 
     {
-      "package": "@segment/facade",
-      "spdx": "MIT",
-      "reason": "Genuinely MIT (LICENSE file is the MIT text). package.json declares 'SEE LICENSE IN LICENSE', so the checker reports it as 'Custom: LICENSE' and PARANOID flags it. Confirmed MIT.",
-      "parents": ["@web3auth/modal"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@segment/isodate",
-      "spdx": "MIT",
-      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
-      "parents": ["@segment/isodate-traverse"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@segment/isodate-traverse",
-      "spdx": "MIT",
-      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
-      "parents": ["@segment/facade"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "new-date",
-      "spdx": "MIT",
-      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
-      "parents": ["@segment/isodate-traverse"],
-      "reviewDate": "2026-06-01"
-    },
-
-    {
-      "package": "jsonify",
-      "spdx": "Public Domain",
-      "reason": "Public domain (unrestricted), declared in package.json. More permissive than MIT.",
-      "parents": ["json-stable-stringify"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "text-encoding-utf-8",
-      "spdx": "Unlicense/Public Domain",
-      "reason": "LICENSE.md is the Unlicense (public-domain) text. No SPDX in package.json so reports as Public Domain. Unrestricted.",
-      "parents": ["@toruslabs/eccrypto"],
-      "reviewDate": "2026-06-01"
-    },
-
-    {
       "package": "@web3auth/modal",
       "spdx": "UNKNOWN (no SPDX declared)",
       "reason": "Web3Auth SDK (direct dep, used by pearl-api). No license field in package.json so reports UNKNOWN. Accepted auth SDK — confirm upstream license terms.",
@@ -123,7 +95,7 @@
     {
       "package": "@metamask/sdk",
       "spdx": "UNKNOWN (no SPDX declared)",
-      "reason": "MetaMask wallet SDK, pulled via RainbowKit's MetaMask connector. No license field so reports UNKNOWN. Accepted wallet SDK.",
+      "reason": "MetaMask wallet SDK, pulled via RainbowKit's MetaMask connector. No license field so reports UNKNOWN. Accepted wallet SDK. (Left as exact names rather than a @metamask/ prefix: that scope mixes permissive and unlicensed packages.)",
       "parents": ["@rainbow-me/rainbowkit"],
       "reviewDate": "2026-06-01"
     },
@@ -146,119 +118,6 @@
       "spdx": "UNKNOWN (no SPDX declared)",
       "reason": "MetaMask SDK component (via RainbowKit). No license field. Accepted wallet SDK.",
       "parents": ["@metamask/sdk"],
-      "reviewDate": "2026-06-01"
-    },
-
-    {
-      "package": "@trezor/connect",
-      "spdx": "T-RSL (Trezor Reference Source License, proprietary)",
-      "reason": "Trezor hardware-wallet SDK, pulled via RainbowKit's Trezor connector. Source-available proprietary license (T-RSL). Accepted wallet SDK.",
-      "parents": ["@rainbow-me/rainbowkit"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/connect-web",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK (web). T-RSL. Accepted wallet SDK.",
-      "parents": ["@rainbow-me/rainbowkit"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/connect-common",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/blockchain-link",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/transport",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/utils",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/utxo-lib",
-      "spdx": "T-RSL (proprietary)",
-      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/analytics",
-      "spdx": "UNKNOWN (Trezor suite, no SPDX declared)",
-      "reason": "Trezor SDK sub-package, no license field (reports UNKNOWN); part of the T-RSL trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/blockchain-link-types",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/blockchain-link"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/blockchain-link-utils",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/blockchain-link"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/connect-analytics",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/env-utils",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/protobuf",
-      "spdx": "UNKNOWN (Trezor suite; package.json points to LICENSE.md)",
-      "reason": "Trezor SDK sub-package. package.json says 'See LICENSE.md in repo root' (T-RSL). Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/protocol",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/schema-utils",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
-      "reviewDate": "2026-06-01"
-    },
-    {
-      "package": "@trezor/type-utils",
-      "spdx": "UNKNOWN (Trezor suite)",
-      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
-      "parents": ["@trezor/connect"],
       "reviewDate": "2026-06-01"
     },
 

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -1,0 +1,293 @@
+{
+  "_comment": "License allowlist gate config — frontend mirror of the backend valory-xyz/tomte `liccheck` PARANOID gate. `allowedSpdx` mirrors tomte's authorized list (permissive + LGPL-2.1/MPL-2.0 weak copyleft). Anything not allowed — including UNKNOWN/Custom — fails unless its exact package NAME is in `exemptions` (version-agnostic). `exemptionPrefixes` is ONLY for platform-binary families whose name varies by OS/arch. Scope is production deps (what ships), matching tomte's frozen-runtime check. See scripts/license-check.mjs and .plans/license-check-gate.md.",
+  "scope": "production",
+  "allowedSpdx": [
+    "MIT",
+    "ISC",
+    "Apache-2.0",
+    "BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "MPL-2.0",
+    "LGPL-2.1",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-2.1+",
+    "BlueOak-1.0.0",
+    "CC0-1.0",
+    "Unlicense",
+    "WTFPL",
+    "Zlib",
+    "Python-2.0",
+    "OFL-1.1",
+    "CC-BY-4.0",
+    "CC-BY-3.0"
+  ],
+  "unauthorizedSpdx": ["GPL-2.0", "GPL-3.0", "LGPL-3.0", "MPL-1.1", "AGPL-3.0"],
+
+  "exemptionPrefixes": [
+    {
+      "prefix": "@img/sharp-libvips-",
+      "spdx": "LGPL-3.0-or-later",
+      "reason": "Platform-specific libvips binaries (image processing). Package name varies by OS/arch (@img/sharp-libvips-darwin-arm64 locally, @img/sharp-libvips-linux-x64 on CI), so a single exact name would be non-deterministic. LGPL-3.0 dynamically-linked native binary, not statically combined with our JS.",
+      "parents": ["sharp"],
+      "reviewDate": "2026-06-01"
+    }
+  ],
+
+  "exemptions": [
+    {
+      "package": "ua-parser-js",
+      "spdx": "AGPL-3.0-or-later",
+      "reason": "Transitive of @rainbow-me/rainbowkit@2.2.11 (browser detection). Already shipping since the RainbowKit migration (#416). NOT pinned to MIT 1.0.37 — that would force a RainbowKit major-version downgrade. AGPL-in-bundle acceptance is an open policy decision; revisit when RainbowKit upstream drops AGPL ua-parser-js.",
+      "parents": ["@rainbow-me/rainbowkit"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "@gnosis.pm/safe-contracts",
+      "spdx": "GPL-3.0",
+      "reason": "Solidity contract sources + ABIs (build-time / ABI-only); not linked into shipped JS. CONFIRM with consuming code before flipping the gate to required.",
+      "parents": ["@safe-global/protocol-kit"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@toruslabs/ffjavascript",
+      "spdx": "GPL-3.0",
+      "reason": "GPL-3.0 finite-field math, pulled transitively by @web3auth/modal (Torus). Resolves itself if @web3auth/modal is replaced.",
+      "parents": ["@web3auth/modal"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "rpc-websockets",
+      "spdx": "LGPL-3.0-only",
+      "reason": "LGPL-3.0 websocket client, transitive of @solana/web3.js. Dynamically required, not statically combined.",
+      "parents": ["@solana/web3.js"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "@segment/facade",
+      "spdx": "MIT",
+      "reason": "Genuinely MIT (LICENSE file is the MIT text). package.json declares 'SEE LICENSE IN LICENSE', so the checker reports it as 'Custom: LICENSE' and PARANOID flags it. Confirmed MIT.",
+      "parents": ["@web3auth/modal"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@segment/isodate",
+      "spdx": "MIT",
+      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
+      "parents": ["@segment/isodate-traverse"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@segment/isodate-traverse",
+      "spdx": "MIT",
+      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
+      "parents": ["@segment/facade"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "new-date",
+      "spdx": "MIT",
+      "reason": "Genuinely MIT (LICENSE file is the MIT text); package.json uses 'SEE LICENSE IN LICENSE'. Confirmed MIT.",
+      "parents": ["@segment/isodate-traverse"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "jsonify",
+      "spdx": "Public Domain",
+      "reason": "Public domain (unrestricted), declared in package.json. More permissive than MIT.",
+      "parents": ["json-stable-stringify"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "text-encoding-utf-8",
+      "spdx": "Unlicense/Public Domain",
+      "reason": "LICENSE.md is the Unlicense (public-domain) text. No SPDX in package.json so reports as Public Domain. Unrestricted.",
+      "parents": ["@toruslabs/eccrypto"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "@web3auth/modal",
+      "spdx": "UNKNOWN (no SPDX declared)",
+      "reason": "Web3Auth SDK (direct dep, used by pearl-api). No license field in package.json so reports UNKNOWN. Accepted auth SDK — confirm upstream license terms.",
+      "parents": ["(root direct dependency)"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "@metamask/sdk",
+      "spdx": "UNKNOWN (no SPDX declared)",
+      "reason": "MetaMask wallet SDK, pulled via RainbowKit's MetaMask connector. No license field so reports UNKNOWN. Accepted wallet SDK.",
+      "parents": ["@rainbow-me/rainbowkit"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@metamask/sdk-communication-layer",
+      "spdx": "UNKNOWN (no SPDX declared)",
+      "reason": "MetaMask SDK component (via RainbowKit). No license field. Accepted wallet SDK.",
+      "parents": ["@metamask/sdk"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@metamask/sdk-install-modal-web",
+      "spdx": "UNKNOWN (no SPDX declared)",
+      "reason": "MetaMask SDK component (via RainbowKit). No license field. Accepted wallet SDK.",
+      "parents": ["@metamask/sdk"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@metamask/eth-json-rpc-provider",
+      "spdx": "UNKNOWN (no SPDX declared)",
+      "reason": "MetaMask SDK component (via RainbowKit). No license field. Accepted wallet SDK.",
+      "parents": ["@metamask/sdk"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "@trezor/connect",
+      "spdx": "T-RSL (Trezor Reference Source License, proprietary)",
+      "reason": "Trezor hardware-wallet SDK, pulled via RainbowKit's Trezor connector. Source-available proprietary license (T-RSL). Accepted wallet SDK.",
+      "parents": ["@rainbow-me/rainbowkit"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/connect-web",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK (web). T-RSL. Accepted wallet SDK.",
+      "parents": ["@rainbow-me/rainbowkit"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/connect-common",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/blockchain-link",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/transport",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/utils",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/utxo-lib",
+      "spdx": "T-RSL (proprietary)",
+      "reason": "Trezor SDK component. T-RSL. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/analytics",
+      "spdx": "UNKNOWN (Trezor suite, no SPDX declared)",
+      "reason": "Trezor SDK sub-package, no license field (reports UNKNOWN); part of the T-RSL trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/blockchain-link-types",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/blockchain-link"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/blockchain-link-utils",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/blockchain-link"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/connect-analytics",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/env-utils",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/protobuf",
+      "spdx": "UNKNOWN (Trezor suite; package.json points to LICENSE.md)",
+      "reason": "Trezor SDK sub-package. package.json says 'See LICENSE.md in repo root' (T-RSL). Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/protocol",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/schema-utils",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+    {
+      "package": "@trezor/type-utils",
+      "spdx": "UNKNOWN (Trezor suite)",
+      "reason": "Trezor SDK sub-package, no license field. Part of trezor-suite. Accepted wallet SDK.",
+      "parents": ["@trezor/connect"],
+      "reviewDate": "2026-06-01"
+    },
+
+    {
+      "package": "web3",
+      "spdx": "LGPL-3.0",
+      "reason": "TEMPORARY. web3 1.x is unused (no source imports; root-only dep, confirmed via yarn why). Scheduled for removal in a separate build-verified PR; delete this entry and all web3-* entries below once that lands.",
+      "parents": ["(root direct dependency)"],
+      "reviewDate": "2026-06-01"
+    },
+    { "package": "web3-bzz", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3 (see web3 entry).", "parents": ["web3"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core-helpers", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core-method", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core-promievent", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core-requestmanager", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
+    { "package": "web3-core-subscriptions", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-abi", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-accounts", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-contract", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-ens", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-iban", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-eth-personal", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-net", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
+    { "package": "web3-providers-http", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
+    { "package": "web3-providers-ipc", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
+    { "package": "web3-providers-ws", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
+    { "package": "web3-shh", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
+    { "package": "web3-utils", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" }
+  ]
+}

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "License allowlist gate config — frontend mirror of the backend valory-xyz/tomte `liccheck` PARANOID gate. `allowedSpdx` mirrors tomte's authorized list (permissive + LGPL-2.1/MPL-2.0 weak copyleft). A package whose license is not allowed — including UNKNOWN/Custom — fails, unless (1) it has a `licenseOverrides` correction, (2) its exact NAME is in `exemptions` (version-agnostic), or (3) its name matches an `exemptionPrefixes` entry. Scope is production deps (what ships). See scripts/license-check.mjs and .plans/license-check-gate.md.",
+  "_comment": "License allowlist gate config. `allowedSpdx` is the set of accepted licenses (permissive plus the LGPL-2.1/MPL-2.0 weak-copyleft licenses). A production dependency whose license is not allowed — including UNKNOWN/Custom — fails the gate, unless (1) it has a `licenseOverrides` correction, (2) its exact NAME is in `exemptions` (version-agnostic), or (3) its name matches an `exemptionPrefixes` entry. Scope is production deps (what ships). See scripts/license-check.mjs.",
   "scope": "production",
   "allowedSpdx": [
     "MIT",

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -119,34 +119,6 @@
       "reason": "MetaMask SDK component (via RainbowKit). No license field. Accepted wallet SDK.",
       "parents": ["@metamask/sdk"],
       "reviewDate": "2026-06-01"
-    },
-
-    {
-      "package": "web3",
-      "spdx": "LGPL-3.0",
-      "reason": "TEMPORARY. web3 1.x is unused (no source imports; root-only dep, confirmed via yarn why). Scheduled for removal in a separate build-verified PR; delete this entry and all web3-* entries below once that lands.",
-      "parents": ["(root direct dependency)"],
-      "reviewDate": "2026-06-01"
-    },
-    { "package": "web3-bzz", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3 (see web3 entry).", "parents": ["web3"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core-helpers", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core-method", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core-promievent", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core-requestmanager", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
-    { "package": "web3-core-subscriptions", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-abi", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-accounts", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-contract", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-ens", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-iban", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-eth-personal", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-net", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-eth"], "reviewDate": "2026-06-01" },
-    { "package": "web3-providers-http", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
-    { "package": "web3-providers-ipc", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
-    { "package": "web3-providers-ws", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core-requestmanager"], "reviewDate": "2026-06-01" },
-    { "package": "web3-shh", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3"], "reviewDate": "2026-06-01" },
-    { "package": "web3-utils", "spdx": "LGPL-3.0", "reason": "TEMPORARY — web3 1.x family, removed with web3.", "parents": ["web3-core"], "reviewDate": "2026-06-01" }
+    }
   ]
 }

--- a/.supply-chain/license-allowlist.json
+++ b/.supply-chain/license-allowlist.json
@@ -56,17 +56,17 @@
     {
       "package": "ua-parser-js",
       "spdx": "AGPL-3.0-or-later",
-      "reason": "Transitive of @rainbow-me/rainbowkit@2.2.11 (browser detection). Already shipping since the RainbowKit migration (#416). NOT pinned to MIT 1.0.37 — that would force a RainbowKit major-version downgrade. AGPL-in-bundle acceptance is an open policy decision; revisit when RainbowKit upstream drops AGPL ua-parser-js.",
+      "reason": "Transitive of @rainbow-me/rainbowkit@2.2.11 (browser detection). Shipping since the RainbowKit migration (#416). SETTLEMENT 2026-06-05: ACCEPTED — not pinned to MIT 1.0.37 (would force a major-version downgrade on the freshly-migrated RainbowKit wallet path) and not removable without dropping RainbowKit. Single low-surface browser-detection lib; legal ratification of AGPL-in-bundle remains the owner's call. Revisit when RainbowKit upstream drops AGPL ua-parser-js.",
       "parents": ["@rainbow-me/rainbowkit"],
-      "reviewDate": "2026-06-01"
+      "reviewDate": "2026-06-05"
     },
 
     {
       "package": "@gnosis.pm/safe-contracts",
       "spdx": "GPL-3.0",
-      "reason": "Solidity contract sources + ABIs (build-time / ABI-only); not linked into shipped JS. CONFIRM with consuming code before flipping the gate to required.",
-      "parents": ["@safe-global/protocol-kit"],
-      "reviewDate": "2026-06-01"
+      "reason": "GPL-3.0. INVESTIGATED 2026-06-05: NOT ABI/build-time-only. Direct dep, imported at RUNTIME by apps/marketplace via require('@gnosis.pm/safe-contracts'); it calls buildSafeTransaction()/buildMultiSendSafeTx() in the Safe multisig service-registration flow (components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx), so GPL JS helpers ARE bundled into the shipped marketplace app. SETTLEMENT: recommended removal by replacing those two helpers with @safe-global/protocol-kit (already a dep) and dropping this package — tracked as a follow-up. Until then GPL-in-bundle is accepted on this single dep, eyes open.",
+      "parents": ["(root direct dependency; runtime-imported by apps/marketplace)"],
+      "reviewDate": "2026-06-05"
     },
     {
       "package": "@toruslabs/ffjavascript",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
     "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
     "lint:lockfile": "lockfile-lint --path yarn.lock --type yarn --allowed-hosts registry.yarnpkg.com registry.npmjs.org --validate-https --validate-integrity",
+    "license-check": "node scripts/license-check.mjs",
     "supply-chain": "yarn audit:prod && yarn lint:lockfile && yarn audit:install-hooks"
   },
   "private": true,
@@ -118,6 +119,7 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-environment-node": "29.7.0",
     "jsdom": "22.1.0",
+    "license-checker-rseidelsohn": "4.4.2",
     "lockfile-lint": "5.0.0",
     "next-router-mock": "0.9.13",
     "nx": "v17.2.5",

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * License allowlist gate — frontend mirror of the backend `liccheck` PARANOID gate
+ * (valory-xyz/tomte). Sibling of scripts/audit.mjs and scripts/audit-install-hooks.mjs.
+ *
+ * Engine: license-checker-rseidelsohn (reads actual LICENSE files, so packages that
+ * declare no SPDX string in package.json are detected rather than reported UNKNOWN).
+ *
+ * Config: .supply-chain/license-allowlist.json
+ *   { allowedSpdx: string[], exemptions: [{ package, reason, ... }], scope?: "production" }
+ *
+ * Posture (PARANOID parity): a package whose license is not on `allowedSpdx` — including
+ * UNKNOWN / "Custom: <file>" / UNLICENSED — FAILS, unless its exact name is in `exemptions`.
+ * Exemptions match by package NAME (version-agnostic): resilient to version bumps, but a
+ * NEW unlisted package — even in an already-exempted namespace — still fails.
+ *
+ * Requires Node >= 18 (the pinned license-checker-rseidelsohn@4.4.2). The repo's .nvmrc
+ * is 22.18.0 and CI runs Node 22.x.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const checker = require('license-checker-rseidelsohn');
+
+const ROOT = process.cwd();
+const CONFIG_PATH = path.join(ROOT, '.supply-chain', 'license-allowlist.json');
+
+const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+const allowed = new Set((config.allowedSpdx || []).map((s) => s.trim().toLowerCase()));
+const exemptByName = new Map((config.exemptions || []).map((e) => [e.package, e]));
+// Narrow prefixes ONLY for platform-binary families whose package name varies by OS/arch
+// (e.g. @img/sharp-libvips-<platform>: darwin-arm64 locally, linux-x64 on CI), where a single
+// exact name would be non-deterministic across platforms. Do NOT use for general namespaces —
+// a new unlisted package must still fail the gate.
+const exemptPrefixes = (config.exemptionPrefixes || []).map((e) =>
+  typeof e === 'string' ? e : e.prefix,
+);
+
+const normalizeToken = (tok) =>
+  String(tok)
+    .replace(/^\(+|\)+$/g, '') // strip surrounding parens
+    .replace(/\*+$/, '') // strip trailing '*' (license-checker "guessed from file" marker)
+    .trim()
+    .toLowerCase();
+
+const tokenAllowed = (tok) => allowed.has(normalizeToken(tok));
+
+// SPDX precedence: AND binds tighter than OR — "A AND B OR C" === "(A AND B) OR C".
+const expressionAllowed = (expr) => {
+  const cleaned = String(expr).replace(/^\(+|\)+$/g, '').trim();
+  const orClauses = cleaned.split(/\s+OR\s+/i);
+  if (orClauses.length > 1) return orClauses.some((c) => expressionAllowed(c));
+  const andParts = cleaned.split(/\s+AND\s+/i);
+  if (andParts.length > 1) return andParts.every((p) => expressionAllowed(p));
+  return tokenAllowed(cleaned);
+};
+
+const licenseAllowed = (lic) => {
+  if (!lic) return false;
+  if (Array.isArray(lic)) return lic.some((l) => licenseAllowed(l)); // array => alternatives (OR)
+  if (/^(unknown|unlicensed)$/i.test(lic) || /^custom:/i.test(lic)) return false; // PARANOID
+  return expressionAllowed(lic);
+};
+
+// key is "<name>@<version>", incl. scoped "@scope/name@<version>".
+const pkgName = (key) => key.slice(0, key.lastIndexOf('@'));
+
+const initOpts = { start: ROOT, excludePrivatePackages: true };
+if ((config.scope || 'production') === 'production') initOpts.production = true;
+
+checker.init(initOpts, (err, packages) => {
+  if (err) {
+    console.error('license-check: failed to scan dependency tree:', err.message || err);
+    process.exit(2);
+  }
+
+  const violations = [];
+  const exemptedNamesHit = new Set();
+  const prefixHits = new Set();
+  for (const [key, info] of Object.entries(packages)) {
+    if (licenseAllowed(info.licenses)) continue;
+    const name = pkgName(key);
+    if (exemptByName.has(name)) {
+      exemptedNamesHit.add(name);
+      continue;
+    }
+    const matchedPrefix = exemptPrefixes.find((p) => name.startsWith(p));
+    if (matchedPrefix) {
+      prefixHits.add(matchedPrefix);
+      continue;
+    }
+    violations.push({
+      key,
+      lic: Array.isArray(info.licenses) ? info.licenses.join(' / ') : String(info.licenses),
+      repo: info.repository || '',
+    });
+  }
+
+  const acceptedCount = exemptedNamesHit.size + prefixHits.size;
+  if (acceptedCount) {
+    console.log(
+      `license-check: ${acceptedCount} exempted package group(s) accepted (see .supply-chain/license-allowlist.json).`,
+    );
+  }
+
+  // Keep the exemption file honest: warn about entries that no longer match any violation.
+  const stale = [
+    ...[...exemptByName.keys()].filter((n) => !exemptedNamesHit.has(n)),
+    ...exemptPrefixes.filter((p) => !prefixHits.has(p)),
+  ];
+  if (stale.length) {
+    console.warn(
+      `license-check: WARNING — ${stale.length} exemption(s) no longer needed (remove them): ${stale.join(', ')}`,
+    );
+  }
+
+  if (violations.length === 0) {
+    console.log('license-check: PASS — 0 license violations.');
+    process.exit(0);
+  }
+
+  violations.sort((a, b) => a.lic.localeCompare(b.lic) || a.key.localeCompare(b.key));
+  console.error(
+    `\nlicense-check: FAIL — ${violations.length} package(s) with a disallowed or unresolved license:\n`,
+  );
+  for (const v of violations) {
+    console.error(`  ${v.lic.padEnd(26)} ${v.key}${v.repo ? `  ${v.repo}` : ''}`);
+  }
+  console.error(
+    '\nResolve each:\n' +
+      '  (a) license is fine        -> add the SPDX id to allowedSpdx\n' +
+      '  (b) dependency we accept    -> add its exact name to exemptions (with reason + parents + reviewDate)\n' +
+      '  (c) removable               -> remove the dependency\n' +
+      'Config: .supply-chain/license-allowlist.json\n',
+  );
+  process.exit(1);
+});

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -29,6 +29,10 @@ const CONFIG_PATH = path.join(ROOT, '.supply-chain', 'license-allowlist.json');
 
 const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 const allowed = new Set((config.allowedSpdx || []).map((s) => s.trim().toLowerCase()));
+// Corrections for packages that ARE permissive but the checker can't map to SPDX (e.g.
+// package.json "SEE LICENSE IN LICENSE"). Applied BEFORE the allowlist check so they pass as
+// their real, confirmed license — these are corrections, not policy exceptions. { name: SPDX }.
+const overrides = config.licenseOverrides || {};
 const exemptByName = new Map((config.exemptions || []).map((e) => [e.package, e]));
 // Narrow prefixes ONLY for platform-binary families whose package name varies by OS/arch
 // (e.g. @img/sharp-libvips-<platform>: darwin-arm64 locally, linux-x64 on CI), where a single
@@ -79,9 +83,17 @@ checker.init(initOpts, (err, packages) => {
   const violations = [];
   const exemptedNamesHit = new Set();
   const prefixHits = new Set();
+  const overrideHits = new Set();
+  const installedNames = new Set();
   for (const [key, info] of Object.entries(packages)) {
-    if (licenseAllowed(info.licenses)) continue;
     const name = pkgName(key);
+    installedNames.add(name);
+    const overridden = Object.prototype.hasOwnProperty.call(overrides, name);
+    const effective = overridden ? overrides[name] : info.licenses;
+    if (overridden && !licenseAllowed(info.licenses) && licenseAllowed(effective)) {
+      overrideHits.add(name);
+    }
+    if (licenseAllowed(effective)) continue;
     if (exemptByName.has(name)) {
       exemptedNamesHit.add(name);
       continue;
@@ -104,15 +116,21 @@ checker.init(initOpts, (err, packages) => {
       `license-check: ${acceptedCount} exempted package group(s) accepted (see .supply-chain/license-allowlist.json).`,
     );
   }
+  if (overrideHits.size) {
+    console.log(
+      `license-check: ${overrideHits.size} license override(s) applied (permissive but mis-detected).`,
+    );
+  }
 
-  // Keep the exemption file honest: warn about entries that no longer match any violation.
+  // Keep the config honest: warn about entries that no longer match any installed package.
   const stale = [
     ...[...exemptByName.keys()].filter((n) => !exemptedNamesHit.has(n)),
     ...exemptPrefixes.filter((p) => !prefixHits.has(p)),
+    ...Object.keys(overrides).filter((n) => !installedNames.has(n)),
   ];
   if (stale.length) {
     console.warn(
-      `license-check: WARNING — ${stale.length} exemption(s) no longer needed (remove them): ${stale.join(', ')}`,
+      `license-check: WARNING — ${stale.length} stale config entr(y/ies) no longer match any package (remove them): ${stale.join(', ')}`,
     );
   }
 

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /**
- * License allowlist gate — frontend mirror of the backend `liccheck` PARANOID gate
- * (valory-xyz/tomte). Sibling of scripts/audit.mjs and scripts/audit-install-hooks.mjs.
+ * License allowlist gate. Sibling of scripts/audit.mjs and scripts/audit-install-hooks.mjs.
  *
  * Engine: license-checker-rseidelsohn (reads actual LICENSE files, so packages that
  * declare no SPDX string in package.json are detected rather than reported UNKNOWN).
@@ -9,7 +8,7 @@
  * Config: .supply-chain/license-allowlist.json
  *   { allowedSpdx: string[], exemptions: [{ package, reason, ... }], scope?: "production" }
  *
- * Posture (PARANOID parity): a package whose license is not on `allowedSpdx` — including
+ * Posture: a package whose license is not on `allowedSpdx` — including
  * UNKNOWN / "Custom: <file>" / UNLICENSED — FAILS, unless its exact name is in `exemptions`.
  * Exemptions match by package NAME (version-agnostic): resilient to version bumps, but a
  * NEW unlisted package — even in an already-exempted namespace — still fails.
@@ -64,7 +63,7 @@ const expressionAllowed = (expr) => {
 const licenseAllowed = (lic) => {
   if (!lic) return false;
   if (Array.isArray(lic)) return lic.some((l) => licenseAllowed(l)); // array => alternatives (OR)
-  if (/^(unknown|unlicensed)$/i.test(lic) || /^custom:/i.test(lic)) return false; // PARANOID
+  if (/^(unknown|unlicensed)$/i.test(lic) || /^custom:/i.test(lic)) return false; // unresolved => fail
   return expressionAllowed(lic);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,6 +3785,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@npmcli/fs@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.1.tgz#59cdaa5adca95d135fc00f2bb53f5771575ce726"
+  integrity sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==
+  dependencies:
+    semver "^7.3.5"
+
 "@nrwl/devkit@v17.2.5":
   version "17.2.5"
   resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-17.2.5.tgz#990918387fb192732c1803c0015bac171f402685"
@@ -8536,6 +8543,11 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 abitype@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.6.tgz#76410903e1d88e34f1362746e2d407513c38565b"
@@ -8862,6 +8874,11 @@ array-buffer-byte-length@^1.0.2:
   dependencies:
     call-bound "^1.0.3"
     is-array-buffer "^3.0.5"
+
+array-find-index@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -9898,6 +9915,14 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@5.6.2, chalk@^5.4.1:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
@@ -9916,14 +9941,6 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -12814,7 +12831,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.3.10:
+glob@^10.2.2, glob@^10.3.10:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -13074,6 +13091,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -13139,6 +13163,13 @@ hosted-git-info@^4.0.1:
   integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
   dependencies:
     lru-cache "^6.0.0"
+
+hosted-git-info@^6.0.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.3.tgz#2ee1a14a097a1236bddf8672c35b613c46c55946"
+  integrity sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==
+  dependencies:
+    lru-cache "^7.5.1"
 
 hosted-git-info@^7.0.0:
   version "7.0.1"
@@ -13678,6 +13709,13 @@ is-core-module@^2.16.0, is-core-module@^2.16.1:
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
+
+is-core-module@^2.8.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1:
   version "1.0.1"
@@ -14810,6 +14848,11 @@ json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-parse-even-better-errors@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz#b43d35e89c0f3be6b5fbbe9dc6c82467b30c28da"
+  integrity sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==
+
 json-rpc-engine@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz#bf5ff7d029e1c1bf20cb6c0e9f348dcd8be5a393"
@@ -15010,6 +15053,23 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+license-checker-rseidelsohn@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/license-checker-rseidelsohn/-/license-checker-rseidelsohn-4.4.2.tgz#c8136cd5708ef68e5560445bd171cc4a5dc536df"
+  integrity sha512-Sf8WaJhd2vELvCne+frS9AXqnY/vv591s2/nZcJDwTnoNgltG4mAmoenffVb8L2YPRYbxARLyrHJBC38AVfpuA==
+  dependencies:
+    chalk "4.1.2"
+    debug "^4.3.4"
+    lodash.clonedeep "^4.5.0"
+    mkdirp "^1.0.4"
+    nopt "^7.2.0"
+    read-installed-packages "^2.0.1"
+    semver "^7.3.5"
+    spdx-correct "^3.1.1"
+    spdx-expression-parse "^3.0.1"
+    spdx-satisfies "^5.0.1"
+    treeify "^1.1.0"
+
 lilconfig@^3.0.0, lilconfig@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
@@ -15135,6 +15195,11 @@ lodash-es@4.18.1, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -15235,6 +15300,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.5.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 lz-string@^1.5.0:
   version "1.5.0"
@@ -15789,6 +15859,11 @@ mkdirp@^0.5.6:
   dependencies:
     minimist "^1.2.6"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mlly@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.6.1.tgz#0983067dc3366d6314fc5e12712884e6978d028f"
@@ -16053,6 +16128,13 @@ node-releases@^2.0.36:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.44.tgz#212c9b983f5bb70d311dd68c27d55dd0e65d1ca7"
   integrity sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==
 
+nopt@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
+
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -16073,10 +16155,25 @@ normalize-package-data@^3.0.0:
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
+normalize-package-data@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-5.0.0.tgz#abcb8d7e724c40d88462b84982f7cbf6859b4588"
+  integrity sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==
+  dependencies:
+    hosted-git-info "^6.0.0"
+    is-core-module "^2.8.1"
+    semver "^7.3.5"
+    validate-npm-package-license "^3.0.4"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-normalize-package-bin@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz#25447e32a9a7de1f51362c61a559233b89947832"
+  integrity sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==
 
 npm-package-arg@11.0.1:
   version "11.0.1"
@@ -17810,6 +17907,29 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+read-installed-packages@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/read-installed-packages/-/read-installed-packages-2.0.1.tgz#8ba63a9382a5158c37a288c2f21268d6eb9c85eb"
+  integrity sha512-t+fJOFOYaZIjBpTVxiV8Mkt7yQyy4E6MSrrnt5FmPd4enYvpU/9DYGirDmN1XQwkfeuWIhM/iu0t2rm6iSr0CA==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    debug "^4.3.4"
+    read-package-json "^6.0.0"
+    semver "2 || 3 || 4 || 5 || 6 || 7"
+    slide "~1.1.3"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+read-package-json@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-6.0.4.tgz#90318824ec456c287437ea79595f4c2854708836"
+  integrity sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==
+  dependencies:
+    glob "^10.2.2"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^5.0.0"
+    npm-normalize-package-bin "^3.0.0"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -18505,6 +18625,11 @@ secure-compare@3.0.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
+"semver@2 || 3 || 4 || 5 || 6 || 7":
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.2.tgz#194bd65723a28cf82542d2bf176b91c26b343be1"
+  integrity sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==
+
 semver@7.5.3:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
@@ -18760,6 +18885,11 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
+slide@~1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==
+
 slugify@^1.3.4, slugify@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
@@ -18884,7 +19014,16 @@ sparse-array@^1.3.1:
   resolved "https://registry.yarnpkg.com/sparse-array/-/sparse-array-1.3.2.tgz#0e1a8b71706d356bc916fe754ff496d450ec20b0"
   integrity sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==
 
-spdx-correct@^3.0.0:
+spdx-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-compare/-/spdx-compare-1.0.0.tgz#2c55f117362078d7409e6d7b08ce70a857cd3ed7"
+  integrity sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==
+  dependencies:
+    array-find-index "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-ranges "^2.0.0"
+
+spdx-correct@^3.0.0, spdx-correct@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
   integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
@@ -18897,7 +19036,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
   integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
 
-spdx-expression-parse@^3.0.0:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
@@ -18909,6 +19048,20 @@ spdx-license-ids@^3.0.0:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
   integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
+
+spdx-ranges@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/spdx-ranges/-/spdx-ranges-2.1.1.tgz#87573927ba51e92b3f4550ab60bfc83dd07bac20"
+  integrity sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==
+
+spdx-satisfies@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz#9feeb2524686c08e5f7933c16248d4fdf07ed6a6"
+  integrity sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==
+  dependencies:
+    spdx-compare "^1.0.0"
+    spdx-expression-parse "^3.0.0"
+    spdx-ranges "^2.0.0"
 
 split-on-first@^1.0.0:
   version "1.1.0"
@@ -19670,6 +19823,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+treeify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
+  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
+
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
@@ -20398,7 +20556,7 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
## What

A license allowlist gate: every **production** dependency's license must be on an accepted-licenses list (permissive + LGPL-2.1/MPL-2.0 weak copyleft), or be an explicitly-reasoned exemption. Unknown/unresolved licenses are treated as violations.

Engine: `license-checker-rseidelsohn` (reads actual `LICENSE` files, so packages declaring no SPDX string are detected rather than reported `UNKNOWN`).

## Files
- **`scripts/license-check.mjs`** — the gate. SPDX `OR`/`AND` handling, fails on unresolved licenses, exemptions matched by exact package name (version-agnostic) + a narrow platform-binary prefix (`@img/sharp-libvips-`). Sibling of the existing `audit` / `install-hooks` gates.
- **`.supply-chain/license-allowlist.json`** — allowed SPDX list, `licenseOverrides` (mislabeled-but-permissive corrections), and reasoned `exemptions` (each with a reason + reviewDate).
- **`supply-chain.yml`** — non-blocking CI job, intentionally **not** in the `all-checks-passed` aggregator yet (reports without gating merges).
- **`package.json`** — one devDependency (`license-checker-rseidelsohn@4.4.2`) + one `license-check` script. No production dependency or resolutions change.

## Result
`yarn license-check` → **PASS, 0 violations** — 9 exemptions + 2 prefixes (wallet SDKs: Trezor/MetaMask/Web3Auth; GPL `@gnosis.pm/safe-contracts` + `@toruslabs/ffjavascript`; LGPL-3.0 `rpc-websockets` + sharp-libvips; AGPL `ua-parser-js`) + 4 `licenseOverrides` (genuinely-MIT packages the checker mislabels).

## Notes
- Pinned `license-checker-rseidelsohn@4.4.2` — the 5.x line requires Node 24; 4.4.2 needs Node ≥ 18, matching the repo's pinned Node 22.
- **Non-blocking pilot.** Promote to a required gate later by adding `license-check` to the `all-checks-passed` job's `needs:` (+ branch protection).
- Each copyleft/proprietary exemption carries a reason + reviewDate; the AGPL (`ua-parser-js`) and GPL (`@gnosis.pm/safe-contracts`) entries document the accepted-with-eyes-open rationale.