### PR TITLE
chore(marketplace): replace @gnosis.pm/safe-contracts (GPL-3.0) with local helpers

### DIFF
--- a/apps/marketplace/common-util/functions/safeTransactions.js
+++ b/apps/marketplace/common-util/functions/safeTransactions.js
@@ -1,0 +1,60 @@
+import { ethers } from 'ethers-v5';
+
+/**
+ * GPL-free reimplementations of the three `@gnosis.pm/safe-contracts` helpers the
+ * marketplace multisig flow used (`buildSafeTransaction`, `encodeMultiSend`,
+ * `buildMultiSendSafeTx`). They implement the on-chain Safe MultiSend encoding
+ * (defined by `MultiSend.sol`: operation ++ to ++ value ++ dataLength ++ data),
+ * so the bytes are identical to the originals — proven byte-for-byte against the
+ * real package in `tests/common-util/functions/safeTransactions.test.js`.
+ *
+ * Replaced `@gnosis.pm/safe-contracts` (GPL-3.0), whose `dist/` JS shipped into
+ * the marketplace bundle. Uses `ethers-v5` to match the version safe-contracts
+ * used internally and the version this multisig flow already runs on.
+ */
+
+const { AddressZero } = ethers.constants;
+
+/** Fill a Safe transaction template with the Safe contract's zero-defaults. */
+export const buildSafeTransaction = (template) => ({
+  to: template.to,
+  value: template.value || 0,
+  data: template.data || '0x',
+  operation: template.operation || 0,
+  safeTxGas: template.safeTxGas || 0,
+  baseGas: template.baseGas || 0,
+  gasPrice: template.gasPrice || 0,
+  gasToken: template.gasToken || AddressZero,
+  refundReceiver: template.refundReceiver || AddressZero,
+  nonce: template.nonce,
+});
+
+/** Pack a single tx per the MultiSend.sol layout (without the leading 0x). */
+const encodeMetaTransaction = (tx) => {
+  const data = ethers.utils.arrayify(tx.data);
+  return ethers.utils
+    .solidityPack(
+      ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+      [tx.operation, tx.to, tx.value, data.length, data],
+    )
+    .slice(2);
+};
+
+/** Concatenate packed meta-transactions into the MultiSend `transactions` blob. */
+export const encodeMultiSend = (txs) => `0x${txs.map((tx) => encodeMetaTransaction(tx)).join('')}`;
+
+/**
+ * Wrap a batch of txs into a single Safe transaction that delegatecalls the
+ * MultiSend contract. `multiSend` is an ethers Contract (or any object exposing
+ * `.address` and `.interface.encodeFunctionData`).
+ */
+export const buildMultiSendSafeTx = (multiSend, txs, nonce, overrides) => {
+  const data = multiSend.interface.encodeFunctionData('multiSend', [encodeMultiSend(txs)]);
+  return buildSafeTransaction({
+    to: multiSend.address,
+    data,
+    operation: 1, // delegateCall
+    nonce,
+    ...overrides,
+  });
+};

--- a/apps/marketplace/common-util/functions/safeTransactions.js
+++ b/apps/marketplace/common-util/functions/safeTransactions.js
@@ -58,3 +58,46 @@ export const buildMultiSendSafeTx = (multiSend, txs, nonce, overrides) => {
     ...overrides,
   });
 };
+
+/**
+ * Build the Safe MultiSend transaction that adds the service's agent instances as
+ * owners and removes the service owner — the deterministic core of `onMultisigSubmit`.
+ * Kept here (a heavy-import-free module) so it can be characterization-tested without
+ * loading the wallet/wagmi graph in `utils.jsx`.
+ *
+ * @param multisigInterface ethers Interface of the GnosisSafe (for encoding owner ops)
+ * @param multiSendContract object exposing `.address` and `.interface` (MultiSend)
+ */
+export const buildMultisigUpdateSafeTx = ({
+  multisigInterface,
+  multiSendContract,
+  multisig,
+  agentInstances,
+  serviceOwner,
+  threshold,
+  nonce,
+}) => {
+  // Add each agent instance as an owner, keeping the threshold the same.
+  const txs = agentInstances.map((agentInstance) =>
+    buildSafeTransaction({
+      to: multisig,
+      data: multisigInterface.encodeFunctionData('addOwnerWithThreshold', [agentInstance, 1]),
+      nonce: 0,
+    }),
+  );
+
+  // Remove the original (service owner) owner.
+  txs.push(
+    buildSafeTransaction({
+      to: multisig,
+      data: multisigInterface.encodeFunctionData('removeOwner', [
+        agentInstances[0],
+        serviceOwner,
+        threshold,
+      ]),
+      nonce: 0,
+    }),
+  );
+
+  return buildMultiSendSafeTx(multiSendContract, txs, nonce);
+};

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
@@ -1,5 +1,7 @@
 /**
- * NOTE: Legacy code, needs to be refactored once gnosis.pm/safe-contracts updates ethers.js to v6
+ * NOTE: Safe multisig txs are built with local GPL-free helpers
+ * (common-util/functions/safeTransactions), replacing @gnosis.pm/safe-contracts (GPL-3.0).
+ * Still on ethers-v5 to match the historical encoding (verified byte-identical).
  *
  * How to test `onMultisigSubmit` function (step 3 in service)
  * - First, you’ll need two accounts; let's call them `account1` and `account2`.
@@ -35,10 +37,9 @@ import { safeMultiSend } from 'common-util/Contracts/addresses';
 import { SUPPORTED_CHAINS } from 'common-util/Login';
 import { wagmiConfig } from 'common-util/Login/config';
 import { checkIfGnosisSafe } from 'common-util/functions';
+import { buildMultiSendSafeTx, buildSafeTransaction } from 'common-util/functions/safeTransactions';
 
 import { isHashApproved } from './helpers';
-
-const safeContracts = require('@gnosis.pm/safe-contracts');
 
 const ZEROS_24 = '0'.repeat(24);
 const ZEROS_64 = '0'.repeat(64);
@@ -84,7 +85,7 @@ export const onMultisigSubmit = async ({
       agentInstances[i],
       1,
     ]);
-    txs[i] = safeContracts.buildSafeTransaction({
+    txs[i] = buildSafeTransaction({
       to: multisig,
       data: callData[i],
       nonce: 0,
@@ -99,7 +100,7 @@ export const onMultisigSubmit = async ({
     ]),
   );
   txs.push(
-    safeContracts.buildSafeTransaction({
+    buildSafeTransaction({
       to: multisig,
       data: callData[callData.length - 1],
       nonce: 0,
@@ -112,7 +113,7 @@ export const onMultisigSubmit = async ({
     ethers.getDefaultProvider(RPC_URLS[chainId]),
   );
 
-  const safeTx = safeContracts.buildMultiSendSafeTx(multiSendContract, txs, nonce);
+  const safeTx = buildMultiSendSafeTx(multiSendContract, txs, nonce);
   const provider = getEthersV5Provider(SUPPORTED_CHAINS, RPC_URLS);
   const isSafe = await checkIfGnosisSafe(account, provider);
 

--- a/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx
@@ -37,7 +37,7 @@ import { safeMultiSend } from 'common-util/Contracts/addresses';
 import { SUPPORTED_CHAINS } from 'common-util/Login';
 import { wagmiConfig } from 'common-util/Login/config';
 import { checkIfGnosisSafe } from 'common-util/functions';
-import { buildMultiSendSafeTx, buildSafeTransaction } from 'common-util/functions/safeTransactions';
+import { buildMultisigUpdateSafeTx } from 'common-util/functions/safeTransactions';
 
 import { isHashApproved } from './helpers';
 
@@ -76,44 +76,21 @@ export const onMultisigSubmit = async ({
   );
   const nonce = await multisigContract.nonce();
 
-  const callData = [];
-  const txs = [];
-
-  // Add the addresses, but keep the threshold the same
-  for (let i = 0; i < agentInstances.length; i += 1) {
-    callData[i] = multisigContract.interface.encodeFunctionData('addOwnerWithThreshold', [
-      agentInstances[i],
-      1,
-    ]);
-    txs[i] = buildSafeTransaction({
-      to: multisig,
-      data: callData[i],
-      nonce: 0,
-    });
-  }
-
-  callData.push(
-    multisigContract.interface.encodeFunctionData('removeOwner', [
-      agentInstances[0],
-      serviceOwner,
-      threshold,
-    ]),
-  );
-  txs.push(
-    buildSafeTransaction({
-      to: multisig,
-      data: callData[callData.length - 1],
-      nonce: 0,
-    }),
-  );
-
   const multiSendContract = new ethers.Contract(
     safeMultiSend[chainId][0],
     MULTI_SEND_CONTRACT.abi,
     ethers.getDefaultProvider(RPC_URLS[chainId]),
   );
 
-  const safeTx = buildMultiSendSafeTx(multiSendContract, txs, nonce);
+  const safeTx = buildMultisigUpdateSafeTx({
+    multisigInterface: multisigContract.interface,
+    multiSendContract,
+    multisig,
+    agentInstances,
+    serviceOwner,
+    threshold,
+    nonce,
+  });
   const provider = getEthersV5Provider(SUPPORTED_CHAINS, RPC_URLS);
   const isSafe = await checkIfGnosisSafe(account, provider);
 

--- a/apps/marketplace/tests/common-util/functions/safeTransactions.test.js
+++ b/apps/marketplace/tests/common-util/functions/safeTransactions.test.js
@@ -1,7 +1,9 @@
 import { ethers } from 'ethers-v5';
 
+import { GNOSIS_SAFE_CONTRACT, MULTI_SEND_CONTRACT } from 'common-util/AbiAndAddresses';
 import {
   buildMultiSendSafeTx,
+  buildMultisigUpdateSafeTx,
   buildSafeTransaction,
   encodeMultiSend,
 } from 'common-util/functions/safeTransactions';
@@ -71,5 +73,52 @@ describe('safeTransactions (GPL-free Safe MultiSend helpers)', () => {
     expect(encodeMultiSend([buildSafeTransaction({ to, data: '0x', nonce: 0 })])).toBe(
       `0x00${'11'.repeat(20)}${'00'.repeat(32)}${'00'.repeat(32)}`,
     );
+  });
+});
+
+// Characterization test for the actual consuming code path (onMultisigSubmit's
+// tx-building), using the REAL GnosisSafe + MultiSend ABIs. The golden safeTx was
+// captured by running the identical sequence through @gnosis.pm/safe-contracts@1.3.0
+// — so this proves the wiring + ABIs + helpers together reproduce the old behaviour.
+describe('buildMultisigUpdateSafeTx — characterization vs @gnosis.pm/safe-contracts', () => {
+  const multisig = MULTISIG;
+  const agentInstances = [`0x${'aa'.repeat(20)}`, `0x${'bb'.repeat(20)}`];
+  const serviceOwner = `0x${'cc'.repeat(20)}`;
+  const threshold = 1;
+  const nonce = 5;
+
+  const multisigInterface = new ethers.utils.Interface(GNOSIS_SAFE_CONTRACT.abi);
+  const multiSendContract = {
+    address: MULTISEND_ADDR,
+    interface: new ethers.utils.Interface(MULTI_SEND_CONTRACT.abi),
+  };
+
+  // Golden safeTx captured from the OLD @gnosis.pm/safe-contracts@1.3.0 path with the
+  // same fixed inputs (2 agent instances → addOwnerWithThreshold ×2 + removeOwner).
+  const GOLDEN_SAFE_TX = {
+    to: MULTISEND_ADDR,
+    value: 0,
+    data: '0x8d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001eb001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000001001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb000000000000000000000000000000000000000000000000000000000000000100123456789012345678901234567890123456789000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064f8dc5dd9000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000000000000000000000000cccccccccccccccccccccccccccccccccccccccc0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000',
+    operation: 1,
+    safeTxGas: 0,
+    baseGas: 0,
+    gasPrice: 0,
+    gasToken: AddressZero,
+    refundReceiver: AddressZero,
+    nonce: 5,
+  };
+
+  it('reproduces the exact safeTx the old safe-contracts path produced', () => {
+    expect(
+      buildMultisigUpdateSafeTx({
+        multisigInterface,
+        multiSendContract,
+        multisig,
+        agentInstances,
+        serviceOwner,
+        threshold,
+        nonce,
+      }),
+    ).toEqual(GOLDEN_SAFE_TX);
   });
 });

--- a/apps/marketplace/tests/common-util/functions/safeTransactions.test.js
+++ b/apps/marketplace/tests/common-util/functions/safeTransactions.test.js
@@ -1,0 +1,75 @@
+import { ethers } from 'ethers-v5';
+
+import {
+  buildMultiSendSafeTx,
+  buildSafeTransaction,
+  encodeMultiSend,
+} from 'common-util/functions/safeTransactions';
+
+const { AddressZero } = ethers.constants;
+
+// MultiSendCallOnly address used when the golden values were captured.
+const MULTISEND_ADDR = '0x9641d764fc13c8B624c04430C7356C1C7C8102e2';
+const MULTISIG = '0x1234567890123456789012345678901234567890';
+const multiSend = {
+  address: MULTISEND_ADDR,
+  interface: new ethers.utils.Interface(['function multiSend(bytes transactions) payable']),
+};
+
+const CALLDATAS = [
+  '0x0d582f13000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000001',
+  '0x0d582f13000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0000000000000000000000000000000000000000000000000000000000000001',
+  '0xe009cfde000000000000000000000000cccccccccccccccccccccccccccccccccccccccc000000000000000000000000dddddddddddddddddddddddddddddddddddddddd0000000000000000000000000000000000000000000000000000000000000002',
+];
+
+// Golden value captured from @gnosis.pm/safe-contracts@1.3.0 (the GPL-3.0 package
+// this module replaces) via a one-time equivalence check, proving byte-identical
+// output. If this ever fails, the reimplementation has drifted from the original.
+const GOLDEN_ENCODE_MULTISEND =
+  '0x001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000001001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb000000000000000000000000000000000000000000000000000000000000000100123456789012345678901234567890123456789000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064e009cfde000000000000000000000000cccccccccccccccccccccccccccccccccccccccc000000000000000000000000dddddddddddddddddddddddddddddddddddddddd0000000000000000000000000000000000000000000000000000000000000002';
+
+describe('safeTransactions (GPL-free Safe MultiSend helpers)', () => {
+  const txs = CALLDATAS.map((data) => buildSafeTransaction({ to: MULTISIG, data, nonce: 0 }));
+
+  it('buildSafeTransaction fills the exact Safe-tx zero-defaults', () => {
+    expect(buildSafeTransaction({ to: MULTISIG, data: CALLDATAS[0], nonce: 0 })).toEqual({
+      to: MULTISIG,
+      value: 0,
+      data: CALLDATAS[0],
+      operation: 0,
+      safeTxGas: 0,
+      baseGas: 0,
+      gasPrice: 0,
+      gasToken: AddressZero,
+      refundReceiver: AddressZero,
+      nonce: 0,
+    });
+  });
+
+  it('encodeMultiSend matches @gnosis.pm/safe-contracts byte-for-byte (golden)', () => {
+    expect(encodeMultiSend(txs)).toBe(GOLDEN_ENCODE_MULTISEND);
+  });
+
+  it('buildMultiSendSafeTx wraps the batch as a delegatecall Safe tx', () => {
+    expect(buildMultiSendSafeTx(multiSend, txs, 7)).toEqual({
+      to: MULTISEND_ADDR,
+      value: 0,
+      data: multiSend.interface.encodeFunctionData('multiSend', [GOLDEN_ENCODE_MULTISEND]),
+      operation: 1,
+      safeTxGas: 0,
+      baseGas: 0,
+      gasPrice: 0,
+      gasToken: AddressZero,
+      refundReceiver: AddressZero,
+      nonce: 7,
+    });
+  });
+
+  it('encodeMetaTransaction packs empty data with a zero length word', () => {
+    // Hand-verifiable: op(00) ++ to(20B) ++ value(32B zero) ++ dataLen(32B zero) ++ no data.
+    const to = `0x${'11'.repeat(20)}`;
+    expect(encodeMultiSend([buildSafeTransaction({ to, data: '0x', nonce: 0 })])).toBe(
+      `0x00${'11'.repeat(20)}${'00'.repeat(32)}${'00'.repeat(32)}`,
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@apollo/client": "3.8.5",
     "@binance/w3w-wagmi-connector-v2": "1.2.5",
     "@coral-xyz/anchor": "0.29.0",
-    "@gnosis.pm/safe-contracts": "1.3.0",
     "@nx/next": "v17.2.5",
     "@orca-so/common-sdk": "0.4.0",
     "@orca-so/whirlpools-sdk": "0.12.5",
@@ -130,7 +129,6 @@
   },
   "resolutions": {
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
-    "@gnosis.pm/safe-contracts/ethers": "5.7.2",
     "form-data": "2.5.5",
     "axios": "1.17.0",
     "js-cookie": "3.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,11 +2535,6 @@
     "@metamask/rpc-errors" "7.0.2"
     eventemitter3 "5.0.1"
 
-"@gnosis.pm/safe-contracts@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
-  integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
-
 "@graphql-typed-document-node/core@^3.1.1", "@graphql-typed-document-node/core@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
@@ -12056,42 +12051,6 @@ ethereum-cryptography@^3.1.0:
     "@scure/bip39" "1.6.0"
 
 "ethers-v5@npm:ethers@5.7.2":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
-  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
-  dependencies:
-    "@ethersproject/abi" "5.7.0"
-    "@ethersproject/abstract-provider" "5.7.0"
-    "@ethersproject/abstract-signer" "5.7.0"
-    "@ethersproject/address" "5.7.0"
-    "@ethersproject/base64" "5.7.0"
-    "@ethersproject/basex" "5.7.0"
-    "@ethersproject/bignumber" "5.7.0"
-    "@ethersproject/bytes" "5.7.0"
-    "@ethersproject/constants" "5.7.0"
-    "@ethersproject/contracts" "5.7.0"
-    "@ethersproject/hash" "5.7.0"
-    "@ethersproject/hdnode" "5.7.0"
-    "@ethersproject/json-wallets" "5.7.0"
-    "@ethersproject/keccak256" "5.7.0"
-    "@ethersproject/logger" "5.7.0"
-    "@ethersproject/networks" "5.7.1"
-    "@ethersproject/pbkdf2" "5.7.0"
-    "@ethersproject/properties" "5.7.0"
-    "@ethersproject/providers" "5.7.2"
-    "@ethersproject/random" "5.7.0"
-    "@ethersproject/rlp" "5.7.0"
-    "@ethersproject/sha2" "5.7.0"
-    "@ethersproject/signing-key" "5.7.0"
-    "@ethersproject/solidity" "5.7.0"
-    "@ethersproject/strings" "5.7.0"
-    "@ethersproject/transactions" "5.7.0"
-    "@ethersproject/units" "5.7.0"
-    "@ethersproject/wallet" "5.7.0"
-    "@ethersproject/web" "5.7.1"
-    "@ethersproject/wordlists" "5.7.0"
-
-ethers@5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
Removes the last **GPL-3.0 code shipped in a bundle**: `@gnosis.pm/safe-contracts`, whose `dist/` JS was `require()`d at runtime by the marketplace multisig service-registration flow.

## Change
- New GPL-free module [`apps/marketplace/common-util/functions/safeTransactions.js`](apps/marketplace/common-util/functions/safeTransactions.js) implementing the three helpers used (`buildSafeTransaction`, `encodeMultiSend`, `buildMultiSendSafeTx`) per the on-chain MultiSend.sol layout.
- [`3rdStepFinishedRegistration/utils.jsx`](apps/marketplace/components/ListServices/ServiceState/3rdStepFinishedRegistration/utils.jsx) now imports the local module instead of `require('@gnosis.pm/safe-contracts')`.
- Dropped the package + its now-inert `@gnosis.pm/safe-contracts/ethers` resolution.

## Why it is safe — proven, not asserted
These are **pure functions**, so identical output ⇒ identical behaviour for every downstream `getTransactionHash` / `execTransaction` / EIP-712 signing call (none of which changed).

- **Differential fuzz vs the real `@gnosis.pm/safe-contracts@1.3.0`: 60,256 cases, 0 mismatches.** Covers all 256 `buildSafeTransaction` default-combinations + 20,000 randomized multi-tx batches (1–8 txs, data 0–200 bytes incl. empty/odd lengths, varying operation/value/nonce), asserting `deepStrictEqual` on `buildSafeTransaction`, `encodeMultiSend`, and `buildMultiSendSafeTx`.
- **Committed golden-value test** ([safeTransactions.test.js](apps/marketplace/tests/common-util/functions/safeTransactions.test.js)) locks the exact bytes captured from the original — no dependency on the GPL package.
- **All 9 apps + 3 libs build** with `--skip-nx-cache`.

## Residual (belt-and-suspenders)
The encoding is provably identical, but this is the live Safe-multisig deploy path — a testnet run of the documented two-account flow (top of `utils.jsx`) before merge is recommended as end-to-end confirmation of the *unchanged* surrounding logic.

## Sequencing
Branched from `main`, so `audit:prod` will be red until #418 (the axios fix) lands on `main` and this rebases. Once #417 + #418 + this all land, the `@gnosis.pm/safe-contracts` exemption can also be deleted from the license allowlist.