### PR TITLE
feat(govern): [BDMARK-2185] shareable deep-links to on-chain proposals

### DIFF
--- a/apps/govern/CLAUDE.md
+++ b/apps/govern/CLAUDE.md
@@ -53,7 +53,15 @@ Unlike other L2 chains (which use `0x` bridge payload and zero value), Arbitrum 
 - Contract references: [`ArbitrumDepositProcessorL1.sol`](https://github.com/valory-xyz/autonolas-tokenomics/blob/main/contracts/staking/ArbitrumDepositProcessorL1.sol), [`DefaultDepositProcessorL1.sol`](https://github.com/valory-xyz/autonolas-tokenomics/blob/main/contracts/staking/DefaultDepositProcessorL1.sol).
 - Tests: `common-util/functions/arbitrum-bridge.spec.ts` and `hooks/useClaimStakingIncentivesBatch.spec.ts`.
 
+## Proposal deep-linking
+
+Individual on-chain proposals are shareable via `/proposals?proposalId=<proposalId>`:
+
+- `components/Proposals/ProposalsList.tsx` reads `query.proposalId`, expands that row, and scrolls it into view (each row is anchored with `id="proposal-<proposalId>"` via `onRow`). Note the subgraph sets entity `id === proposalId`, so the table's `rowKey="id"` matches the `expandedRowKeys` (which use `proposalId`).
+- `components/Proposals/ProposalDetails.tsx` exposes a **Copy link** button that writes the absolute URL to the clipboard.
+
 ## Notes
 
 - Voting and delegation logic depends on governor contracts and subgraph; ensure correct chain and subgraph URL.
 - Balance and vote displays are wallet/contract-driven.
+- Quorum column: for settled/started proposals the displayed quorum equals on-chain `GovernorOLAS.quorum(startBlock)` (3% of veOLAS `getPastTotalSupply` at the snapshot block = creation + `votingDelay`, ~1.8 days). For not-yet-started proposals `hooks/useProposals.ts` shows an **approximate** value computed at the current block (prefixed `~`), identical across all pending proposals. `useBlock()` there is not pinned to `mainnet.id`, so status/approximation can be wrong if the wallet is on a non-mainnet chain.

--- a/apps/govern/components/Proposals/ProposalDetails.tsx
+++ b/apps/govern/components/Proposals/ProposalDetails.tsx
@@ -58,11 +58,6 @@ export const ProposalDetails = ({
 
   return (
     <Flex vertical>
-      <Flex justify="flex-end" className="mb-8">
-        <Button size="small" icon={<LinkOutlined />} onClick={handleCopyLink}>
-          Copy link
-        </Button>
-      </Flex>
       <Caption>Proposal description</Caption>
       <Paragraph className="mb-16">{item.description}</Paragraph>
       <Caption>Owner</Caption>
@@ -98,7 +93,12 @@ export const ProposalDetails = ({
         ))}
       </Flex>
       <Caption>Proposal ID</Caption>
-      <Paragraph className="mb-16">{item.id}</Paragraph>
+      <Flex align="center" gap={8} className="mb-16">
+        <Paragraph className="m-0">{item.id}</Paragraph>
+        <Button size="small" icon={<LinkOutlined />} onClick={handleCopyLink}>
+          Copy link
+        </Button>
+      </Flex>
 
       <Caption>Transaction</Caption>
       <a

--- a/apps/govern/components/Proposals/ProposalDetails.tsx
+++ b/apps/govern/components/Proposals/ProposalDetails.tsx
@@ -1,10 +1,11 @@
-import { Col, Flex, Row, Skeleton, Typography } from 'antd';
+import { LinkOutlined } from '@ant-design/icons';
+import { Button, Col, Flex, Row, Skeleton, Typography } from 'antd';
 import { Block } from 'viem';
 import { mainnet } from 'viem/chains';
 import { useAccount, useBlock } from 'wagmi';
 
 import { Caption } from 'libs/ui-components/src';
-import { areAddressesEqual } from 'libs/util-functions/src';
+import { areAddressesEqual, notifySuccess } from 'libs/util-functions/src';
 import { AddressLink } from 'libs/ui-components/src';
 
 import { estimateFutureBlockTimestamp, getFullFormattedDate } from 'common-util/functions';
@@ -49,8 +50,19 @@ export const ProposalDetails = ({
   const startDateBlock = useBlockTimestamp(currentBlock, BigInt(item.startBlock));
   const endDateBlock = useBlockTimestamp(currentBlock, BigInt(item.endBlock));
 
+  const handleCopyLink = () => {
+    const url = `${window.location.origin}/proposals?proposalId=${item.proposalId}`;
+    navigator.clipboard.writeText(url);
+    notifySuccess('Link copied to clipboard');
+  };
+
   return (
     <Flex vertical>
+      <Flex justify="flex-end" className="mb-8">
+        <Button size="small" icon={<LinkOutlined />} onClick={handleCopyLink}>
+          Copy link
+        </Button>
+      </Flex>
       <Caption>Proposal description</Caption>
       <Paragraph className="mb-16">{item.description}</Paragraph>
       <Caption>Owner</Caption>

--- a/apps/govern/components/Proposals/ProposalsList.tsx
+++ b/apps/govern/components/Proposals/ProposalsList.tsx
@@ -159,6 +159,14 @@ export const ProposalsList = () => {
     }
   }, [query.proposalId]);
 
+  useEffect(() => {
+    // once proposals are loaded, scroll the deep-linked proposal into view
+    if (isLoading || !query.proposalId || typeof query.proposalId !== 'string') return;
+    document
+      .getElementById(`proposal-${query.proposalId}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [isLoading, query.proposalId]);
+
   const handleExpand = (expanded: boolean, record: Proposal) => {
     const newKeys = expanded
       ? [...expandedRowKeys, record.proposalId]
@@ -207,6 +215,7 @@ export const ProposalsList = () => {
       loading={isLoading}
       dataSource={data}
       rowKey="id"
+      onRow={(record) => ({ id: `proposal-${record.proposalId}` })}
       expandable={{
         expandIcon: ({ expanded, onExpand, record }) => {
           const Icon = expanded ? DownOutlined : RightOutlined;


### PR DESCRIPTION
## What

Make individual on-chain proposals shareable via `/proposals?proposalId=<proposalId>`.

- **Copy link button** in the expanded proposal details (`ProposalDetails.tsx`) — copies the absolute URL to the clipboard with a success toast.
- **Scroll-into-view** on load: the deep-linked proposal is expanded *and* scrolled into view. Each row is anchored with `id="proposal-<proposalId>"` via `onRow` (needed because pagination is off and all rows render in one long list).

The read side (`query.proposalId` → expand the matching row) already existed in `ProposalsList.tsx`; this PR adds the means to *produce* the link and to bring the row into view. Note the subgraph sets entity `id === proposalId`, so the table's `rowKey="id"` correctly matches the `expandedRowKeys`.

## Screenshots

<img width="1005" height="88" alt="Screenshot 2026-06-12 155701" src="https://github.com/user-attachments/assets/c29e90ab-b2ac-4473-b49f-abe1da7fd25e" />


## How to test

1. Go to `/proposals` .
2. Expand a proposal → click **Copy link** → "Link copied to clipboard" toast.
3. Paste the URL in a new tab → page loads with that proposal expanded and scrolled into view.

## Notes / out of scope

- Existing multi-expand behavior is preserved; the URL is not auto-rewritten on expand (a single `?proposalId=` can't represent multiple open rows). The explicit Copy link button is the unambiguous share mechanism.
- Unrelated pre-existing issue spotted while here: `useBlock()` in `hooks/useProposals.ts` is not pinned to `mainnet.id`, so proposal status / the approximate (`~`) quorum can be wrong if the wallet is connected to a non-mainnet chain. Documented in `apps/govern/CLAUDE.md`; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)