### PR TITLE
fix(marketplace): [BDMARK-2187] correct viem multi-output reads and guard ENS lookup

### DIFF
--- a/apps/marketplace/common-util/Details/DetailsSubInfo/index.jsx
+++ b/apps/marketplace/common-util/Details/DetailsSubInfo/index.jsx
@@ -1,6 +1,7 @@
 import { Alert, Button } from 'antd';
 import PropTypes from 'prop-types';
 import { useEffect, useMemo, useState } from 'react';
+import { isAddress } from 'viem';
 import { useEnsName } from 'wagmi';
 
 import { NA } from 'libs/util-constants/src';
@@ -48,7 +49,15 @@ export const DetailsSubInfo = ({
   const [tokenAddress, setTokenAddress] = useState(null);
   const [canShowRewards, setCanShowRewards] = useState(null);
 
-  const { data: ownerEnsName } = useEnsName({ address: ownerAddress, chainId: 1 });
+  // Only attempt ENS reverse-resolution for a real address. `ownerAddress` is
+  // the `NA` ('n/a') placeholder until the owner read resolves; passing that to
+  // useEnsName makes viem encode 'n/a' into an ENS CCIP batch-gateway multicall,
+  // which the RPC rejects as "Invalid params" — and because the page's real
+  // reads are batched into the same multicall, they fail too (blank page).
+  const { data: ownerEnsName } = useEnsName({
+    address: isAddress(ownerAddress) ? ownerAddress : undefined,
+    chainId: 1,
+  });
 
   const { hashUrl, metadataLoadState, codeHref, nftImageUrl, description, version } =
     useMetadata(tokenUri);

--- a/apps/marketplace/components/ListServices/ServiceState/index.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/index.jsx
@@ -87,21 +87,25 @@ export const ServiceState = ({ isOwner = false, id, details = [], updateDetails 
   useEffect(() => {
     let isMounted = true;
     const getData = async () => {
-      if (id && (agentIds || []).length !== 0) {
-        const temp = isSvm
-          ? await getSvmServiceTableDataSource(id, agentIds || [])
-          : await getServiceTableDataSource(id, agentIds || []);
-        if (isMounted) {
-          setDataSource(temp);
+      try {
+        if (id && (agentIds || []).length !== 0) {
+          const temp = isSvm
+            ? await getSvmServiceTableDataSource(id, agentIds || [])
+            : await getServiceTableDataSource(id, agentIds || []);
+          if (isMounted) {
+            setDataSource(temp);
+          }
         }
-      }
-      // if valid service id, check if it's an eth token
-      // and SVM is not eth token
-      if (id && chainId && doesNetworkHaveValidServiceManagerToken && !isSvm) {
-        const isEth = await checkIfEth(id);
-        if (isMounted) {
-          setIsEthToken(isEth);
+        // if valid service id, check if it's an eth token
+        // and SVM is not eth token
+        if (id && chainId && doesNetworkHaveValidServiceManagerToken && !isSvm) {
+          const isEth = await checkIfEth(id);
+          if (isMounted) {
+            setIsEthToken(isEth);
+          }
         }
+      } catch (e) {
+        console.error(e);
       }
     };
 

--- a/apps/marketplace/components/ListServices/ServiceState/utils.jsx
+++ b/apps/marketplace/components/ListServices/ServiceState/utils.jsx
@@ -32,7 +32,9 @@ import { transformDatasourceForServiceTable, transformSlotsAndBonds } from '../h
  */
 export const getBonds = async (id, tableDataSource) => {
   const chainId = requireChainId();
-  const response = await readContract(wagmiConfig, {
+  // viem returns multi-output reads as a positional array, not a named object
+  // (web3.js used to give `.agentParams`): getAgentParams -> [numAgentIds, agentParams]
+  const [, agentParams = []] = await readContract(wagmiConfig, {
     ...serviceRegistryParams(chainId),
     functionName: 'getAgentParams',
     args: [BigInt(id)],
@@ -40,13 +42,13 @@ export const getBonds = async (id, tableDataSource) => {
 
   const bondsArray = [];
   const slotsArray = [];
-  for (let i = 0; i < response.agentParams.length; i += 1) {
+  for (let i = 0; i < agentParams.length; i += 1) {
     /**
      * agentParams = [{ slots: 2, bond: 2000 }, { slots: 3, bond: 4000 }]
      * slotsArray = [2, 3]
      * bondsArray = [2000, 4000]
      */
-    const { bond, slots } = response.agentParams[i];
+    const { bond, slots } = agentParams[i];
     slotsArray.push(slots);
     bondsArray.push(bond);
   }
@@ -164,12 +166,14 @@ export const getServiceTableDataSource = async (id, agentIds) => {
    */
   const numAgentInstancesArray = await Promise.all(
     agentIds.map(async (agentId) => {
-      const info = await readContract(wagmiConfig, {
+      // viem returns multi-output reads as a positional array:
+      // getInstancesForAgentId -> [numAgentInstances, agentInstances]
+      const [numAgentInstances] = await readContract(wagmiConfig, {
         ...serviceRegistryParams(chainId),
         functionName: 'getInstancesForAgentId',
         args: [BigInt(id), BigInt(agentId)],
       });
-      return info.numAgentInstances;
+      return numAgentInstances;
     }),
   );
 
@@ -255,12 +259,14 @@ export const getTokenBondRequest = async (id, source) => {
 
 export const getServiceAgentInstances = async (id) => {
   const chainId = requireChainId();
-  const response = await readContract(wagmiConfig, {
+  // viem returns multi-output reads as a positional array:
+  // getAgentInstances -> [numAgentInstances, agentInstances]
+  const [, agentInstances] = await readContract(wagmiConfig, {
     ...serviceRegistryParams(chainId),
     functionName: 'getAgentInstances',
     args: [BigInt(id)],
   });
-  return response?.agentInstances;
+  return agentInstances;
 };
 
 export const onStep3Deploy = async (account, id, radioValue, payload = '0x') => {
@@ -281,13 +287,15 @@ export const onStep3Deploy = async (account, id, radioValue, payload = '0x') => 
 /* ----- step 4 functions ----- */
 export const getAgentInstanceAndOperator = async (id) => {
   const chainId = requireChainId();
-  const response = await readContract(wagmiConfig, {
+  // viem returns multi-output reads as a positional array:
+  // getAgentInstances -> [numAgentInstances, agentInstances]
+  const [, agentInstances] = await readContract(wagmiConfig, {
     ...serviceRegistryParams(chainId),
     functionName: 'getAgentInstances',
     args: [BigInt(id)],
   });
   const data = await Promise.all(
-    (response?.agentInstances || []).map(async (key, index) => {
+    (agentInstances || []).map(async (key, index) => {
       const operatorAddress = await readContract(wagmiConfig, {
         ...serviceRegistryParams(chainId),
         functionName: 'mapAgentInstanceOperators',

--- a/apps/marketplace/tests/components/ListAgents/detailsEnsName.test.jsx
+++ b/apps/marketplace/tests/components/ListAgents/detailsEnsName.test.jsx
@@ -2,7 +2,12 @@ import { render, waitFor } from '@testing-library/react';
 import { useEnsName } from 'wagmi';
 
 import AgentDetails from 'components/ListAgents/details';
-import { getAgentDetails, getAgentHashes, getAgentOwner, getTokenUri } from 'components/ListAgents/utils';
+import {
+  getAgentDetails,
+  getAgentHashes,
+  getAgentOwner,
+  getTokenUri,
+} from 'components/ListAgents/utils';
 import { NA } from 'libs/util-constants/src';
 
 import {

--- a/apps/marketplace/tests/components/ListAgents/detailsEnsName.test.jsx
+++ b/apps/marketplace/tests/components/ListAgents/detailsEnsName.test.jsx
@@ -1,0 +1,142 @@
+import { render, waitFor } from '@testing-library/react';
+import { useEnsName } from 'wagmi';
+
+import AgentDetails from 'components/ListAgents/details';
+import { getAgentDetails, getAgentHashes, getAgentOwner, getTokenUri } from 'components/ListAgents/utils';
+import { NA } from 'libs/util-constants/src';
+
+import {
+  dummyAddress,
+  mockCodeUri,
+  mockNftImageHash,
+  mockV1Hash,
+  svmConnectivityEmptyMock,
+  useHelpersEvmMock,
+  wrapProvider,
+} from '../../tests-helpers';
+
+// Regression guard for the agent-blueprints "Invalid params" RPC failure:
+// `useEnsName` must never receive the `NA` ('n/a') placeholder as `address`.
+// Passing 'n/a' makes viem encode it into an ENS CCIP batch-gateway multicall
+// that the RPC rejects, poisoning the batch and taking the page's real reads
+// (getUnit / mapServiceIdOperatorsCheck) down with it. The fix gates the call
+// on `isAddress(ownerAddress)`, passing `undefined` until a real owner resolves.
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter() {
+    return { query: { id: '1' } };
+  },
+}));
+
+jest.mock('wagmi', () => ({
+  __esModule: true,
+  useEnsName: jest.fn(() => ({ data: undefined })),
+}));
+
+jest.mock('libs/common-contract-functions/src', () => ({
+  useClaimableIncentives: jest.fn().mockReturnValue({
+    reward: '0.85',
+    rewardWei: 850000000000000000,
+    topUp: '222,777.30',
+    topUpWei: 222777300000000000000000000,
+  }),
+  getPendingIncentives: jest.fn().mockResolvedValue({
+    pendingReward: '0.95555',
+    pendingTopUp: '200,500.65',
+  }),
+}));
+
+jest.mock('common-util/List/IpfsHashGenerationModal/helpers', () => ({
+  getIpfsHashHelper: jest.fn(() => mockV1Hash),
+}));
+
+jest.mock('common-util/Details/utils', () => ({
+  checkIfServiceRequiresWhitelisting: jest.fn(() => false),
+}));
+
+jest.mock('common-util/Details/DetailsSubInfo/utils', () => ({
+  getTokenomicsUnitType: jest.fn(() => 1),
+}));
+
+jest.mock('common-util/hooks/useHelpers', () => ({
+  useHelpers: () => useHelpersEvmMock,
+}));
+
+jest.mock('common-util/hooks/useSvmConnectivity', () => ({
+  useSvmConnectivity: () => svmConnectivityEmptyMock,
+}));
+
+jest.mock('components/ListAgents/utils', () => ({
+  getAgentDetails: jest.fn(),
+  getAgentHashes: jest.fn(),
+  getAgentOwner: jest.fn(),
+  getTokenUri: jest.fn(),
+  updateAgentHashes: jest.fn(),
+}));
+
+const dummyDetails = {
+  owner: dummyAddress,
+  developer: dummyAddress,
+  dependencies: [1, 2],
+  tokenUrl: 'https://localhost/component/12345',
+};
+
+const dummyIpfs = {
+  image: `ipfs://${mockNftImageHash}`,
+  name: 'Some package name',
+  description: 'Some description',
+  code_uri: `ipfs://${mockCodeUri}`,
+  attributes: [{ trait_type: 'version', value: '0.0.0.1' }],
+};
+
+const unmockedFetch = global.fetch;
+
+describe('DetailsSubInfo – useEnsName address guard', () => {
+  beforeAll(() => {
+    global.fetch = () =>
+      Promise.resolve({
+        json: () => Promise.resolve(dummyIpfs),
+      });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAgentDetails.mockResolvedValue(dummyDetails);
+    getAgentHashes.mockResolvedValue({ agentHashes: [] });
+    getTokenUri.mockResolvedValue(dummyDetails.tokenUrl);
+  });
+
+  afterAll(() => {
+    global.fetch = unmockedFetch;
+  });
+
+  it('passes the real owner address to useEnsName once resolved (never the NA placeholder)', async () => {
+    getAgentOwner.mockResolvedValue(dummyAddress);
+
+    render(wrapProvider(<AgentDetails />));
+
+    await waitFor(() => {
+      expect(useEnsName).toHaveBeenCalledWith(
+        expect.objectContaining({ address: dummyAddress, chainId: 1 }),
+      );
+    });
+
+    expect(useEnsName).not.toHaveBeenCalledWith(expect.objectContaining({ address: NA }));
+  });
+
+  it('passes undefined (not NA) to useEnsName while the owner is unresolved/NA', async () => {
+    getAgentOwner.mockResolvedValue(NA);
+
+    render(wrapProvider(<AgentDetails />));
+
+    await waitFor(() => {
+      expect(getAgentOwner).toHaveBeenCalled();
+    });
+
+    expect(useEnsName).toHaveBeenCalledWith(
+      expect.objectContaining({ address: undefined, chainId: 1 }),
+    );
+    expect(useEnsName).not.toHaveBeenCalledWith(expect.objectContaining({ address: NA }));
+  });
+});

--- a/apps/marketplace/tests/components/ListServices/serviceStateUtils.test.jsx
+++ b/apps/marketplace/tests/components/ListServices/serviceStateUtils.test.jsx
@@ -1,0 +1,92 @@
+import { readContract } from '@wagmi/core';
+
+import {
+  getBonds,
+  getServiceAgentInstances,
+  getAgentInstanceAndOperator,
+} from '../../../components/ListServices/ServiceState/utils';
+
+// viem's `readContract` returns multi-output reads as a POSITIONAL ARRAY
+// (e.g. getAgentParams -> [numAgentIds, agentParams]), unlike the old web3.js
+// reads which returned a named object (`response.agentParams`). These specs
+// lock in that the utils read the array shape, guarding against the regression
+// that broke the service-state section after the viem migration.
+jest.mock('@wagmi/core', () => ({
+  readContract: jest.fn(),
+  simulateContract: jest.fn(),
+  writeContract: jest.fn(),
+  waitForTransactionReceipt: jest.fn(),
+}));
+
+jest.mock('../../../common-util/functions', () => ({
+  requireChainId: () => 1,
+}));
+
+jest.mock('../../../common-util/Login/config', () => ({
+  wagmiConfig: {},
+}));
+
+// Sever the transitive import chain (helpers/functions -> ListCommon -> hooks
+// -> `wagmi`), whose ESM hooks package isn't transformed by jest. The functions
+// under test don't use convertStringToArray; a stub keeps helpers/functions
+// loadable without pulling in the wagmi React hooks.
+jest.mock('../../../common-util/List/ListCommon', () => ({
+  convertStringToArray: (str) =>
+    typeof str === 'string' ? str.split(',').map((s) => s.trim()) : [],
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ServiceState/utils – viem multi-output array shape', () => {
+  it('getBonds reads the [numAgentIds, agentParams] array', async () => {
+    readContract.mockResolvedValueOnce([
+      2n,
+      [
+        { slots: 2, bond: 2000n },
+        { slots: 3, bond: 4000n },
+      ],
+    ]);
+
+    const { slots, bonds } = await getBonds('1');
+
+    expect(slots).toEqual([2, 3]);
+    expect(bonds).toEqual([2000n, 4000n]);
+  });
+
+  it('getBonds does not throw when agentParams is empty', async () => {
+    readContract.mockResolvedValueOnce([0n, []]);
+
+    const { slots, bonds } = await getBonds('1');
+
+    expect(slots).toEqual([]);
+    expect(bonds).toEqual([]);
+  });
+
+  it('getServiceAgentInstances reads the [num, agentInstances] array', async () => {
+    const instances = ['0xabc', '0xdef'];
+    readContract.mockResolvedValueOnce([2n, instances]);
+
+    const result = await getServiceAgentInstances('1');
+
+    expect(result).toEqual(instances);
+  });
+
+  it('getAgentInstanceAndOperator pairs each instance with its operator', async () => {
+    const instances = ['0xinstance1', '0xinstance2'];
+    readContract
+      // getAgentInstances -> [numAgentInstances, agentInstances]
+      .mockResolvedValueOnce([2n, instances])
+      // mapAgentInstanceOperators(instance) -> operator address
+      .mockResolvedValueOnce('0xoperator1')
+      .mockResolvedValueOnce('0xoperator2');
+
+    const result = await getAgentInstanceAndOperator('1');
+
+    expect(result).toEqual([
+      { id: 'agent-instance-row-1', operatorAddress: '0xoperator1', agentInstance: '0xinstance1' },
+      { id: 'agent-instance-row-2', operatorAddress: '0xoperator2', agentInstance: '0xinstance2' },
+    ]);
+  });
+});


### PR DESCRIPTION
## [BDMARK-2187]

Fixes two distinct regressions on the Marketplace detail pages, both fallout from the **web3.js → viem migration** (not the WalletConnect/RainbowKit change). Each left a page partially blank with console errors.

### 1. Multi-output contract reads — service detail (polygon/gnosis/base, all chains)

**Symptom:** `TypeError: Cannot read properties of undefined (reading 'length')`; the service **State** section renders blank.

**Cause:** viem's `readContract` returns functions with **multiple outputs** as a **positional array**, not the named object web3.js returned. `getBonds` read `response.agentParams.length` → `agentParams` is now `undefined`. Because `ServiceState`'s `getData` effect had no `try/catch`, this surfaced as an **uncaught promise rejection** that aborted the render. The same shape change silently broke `getInstancesForAgentId` (`info.numAgentInstances`) and `getAgentInstances` (`response.agentInstances`).

**Fix:** destructure the positional arrays in all four reads in `ServiceState/utils.jsx`, and wrap `getData` in `try/catch` so a future read error can't blank the page.

### 2. ENS reverse-resolution with the `NA` placeholder — agent-blueprints (ethereum)

**Symptom:** `InvalidParamsRpcError: Invalid parameters were provided to the RPC method`; the whole page shows no data.

**Cause:** `useEnsName` was called with the `NA` (`'n/a'`) owner placeholder before the owner read resolved. viem encodes `'n/a'` into an ENS CCIP **batch-gateway multicall** (`0xeeee…eeee` sentinel + `x-batch-gateway:true`), which the RPC rejects as *Invalid params*. Because the page's legitimate reads (`getUnit`, `mapServiceIdOperatorsCheck`) are **batched into the same multicall**, they fail too — so the whole page renders empty.

**Fix:** gate the call on `isAddress(ownerAddress)`, passing `undefined` until a real owner address resolves.

## Tests

- `tests/components/ListServices/serviceStateUtils.test.jsx` (new) — asserts `getBonds`, `getServiceAgentInstances`, `getAgentInstanceAndOperator` read viem's positional-array shape, and `getBonds` no longer throws on empty `agentParams`. **4 passing.**
- `tests/components/ListAgents/detailsEnsName.test.jsx` (new) — asserts `useEnsName` receives the real address once resolved and `undefined` (never `NA`) while unresolved. **2 passing.**

## Notes / follow-ups (not in this PR)

- The pre-existing `tests/components/ListServices/utils.test.jsx` (and siblings) are `describe.skip` with web3.js-shaped mocks left over from the migration — i.e. the tests that would have caught these bugs are disabled. Worth porting their mocks to viem's `readContract` in a focused PR.
- Other apps in the monorepo went through the same migration; a sweep for `.namedField`-on-multi-output reads and `useEnsName(NA)` is advisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)