### PR TITLE
feat(govern): switch GovernorOLAS to new contract

### DIFF
--- a/libs/util-contracts/src/lib/abiAndAddresses/governorOLAS.js
+++ b/libs/util-contracts/src/lib/abiAndAddresses/governorOLAS.js
@@ -1,7 +1,7 @@
 export const GOVERNOR_OLAS = {
   contractName: 'GovernorOLAS',
   addresses: {
-    1: '0x8e84b5055492901988b831817e4ace5275a3b401',
+    1: '0x060D0CBdDFb0498d610E2EF55C01516B5B1251E6',
   },
   abi: [
     {
@@ -36,6 +36,11 @@ export const GOVERNOR_OLAS = {
           name: 'quorumFraction',
           type: 'uint256',
         },
+        {
+          internalType: 'uint256',
+          name: 'initialGovernorDelay',
+          type: 'uint256',
+        },
       ],
       stateMutability: 'nonpayable',
       type: 'constructor',
@@ -44,6 +49,35 @@ export const GOVERNOR_OLAS = {
       inputs: [],
       name: 'Empty',
       type: 'error',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'provided',
+          type: 'uint256',
+        },
+        {
+          internalType: 'uint256',
+          name: 'min',
+          type: 'uint256',
+        },
+      ],
+      name: 'Underflow',
+      type: 'error',
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newGovernorDelay',
+          type: 'uint256',
+        },
+      ],
+      name: 'GovernorDelayChange',
+      type: 'event',
     },
     {
       anonymous: false,
@@ -729,6 +763,19 @@ export const GOVERNOR_OLAS = {
       type: 'function',
     },
     {
+      inputs: [],
+      name: 'governorDelay',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
       inputs: [
         {
           internalType: 'uint256',
@@ -1198,6 +1245,25 @@ export const GOVERNOR_OLAS = {
       type: 'function',
     },
     {
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'blockNumber',
+          type: 'uint256',
+        },
+      ],
+      name: 'quorumNumerator',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
       inputs: [],
       name: 'quorumNumerator',
       outputs: [
@@ -1243,7 +1309,7 @@ export const GOVERNOR_OLAS = {
       ],
       name: 'relay',
       outputs: [],
-      stateMutability: 'nonpayable',
+      stateMutability: 'payable',
       type: 'function',
     },
     {
@@ -1347,6 +1413,19 @@ export const GOVERNOR_OLAS = {
         },
       ],
       stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'newGovernorDelay',
+          type: 'uint256',
+        },
+      ],
+      name: 'updateGovernorDelay',
+      outputs: [],
+      stateMutability: 'nonpayable',
       type: 'function',
     },
     {


### PR DESCRIPTION
## Summary
Switches the mainnet **GovernorOLAS** contract from the old deployment to the new one.

- **Old:** [`0x8e84b5055492901988b831817e4ace5275a3b401`](https://etherscan.io/address/0x8e84b5055492901988b831817e4ace5275a3b401)
- **New:** [`0x060D0CBdDFb0498d610E2EF55C01516B5B1251E6`](https://etherscan.io/address/0x060D0CBdDFb0498d610E2EF55C01516B5B1251E6)

Updates both the address and the ABI in `libs/util-contracts/src/lib/abiAndAddresses/governorOLAS.js`.

## ABI changes (new vs. old)
- Constructor: added `initialGovernorDelay` argument
- Error: added `Underflow(provided, min)`
- Event: added `GovernorDelayChange`
- Functions: added `governorDelay()`, `updateGovernorDelay(newGovernorDelay)`, and an overloaded `quorumNumerator(blockNumber)` alongside the existing argless `quorumNumerator()`

## Consumers
The `GOVERNOR_OLAS` export is used generically (`.abi` / `.addresses`) in the **govern** app:
- `apps/govern/common-util/functions/requests.ts`
- `apps/govern/hooks/useProposals.ts`

Both pick up the new address/ABI automatically; the `quorum(blockNumber)` call they rely on is unchanged.

No changes needed in `olas-website` — it only references "Governor" as a governance concept, with no contract address.

## Note
The new ABI legitimately contains two `quorumNumerator` entries (argless + `blockNumber` overload). Nothing in the codebase calls it by name today, so no disambiguation is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)