### PR TITLE
fix(launch): stop runaway nominate transactions

### DIFF
--- a/apps/launch/components/NominateContract/index.spec.tsx
+++ b/apps/launch/components/NominateContract/index.spec.tsx
@@ -1,7 +1,10 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
-import { useAccount } from 'wagmi';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useParams } from 'next/navigation';
+import { mainnet } from 'viem/chains';
+import { useAccount, useSwitchChain } from 'wagmi';
 
+import { addNominee } from 'common-util/functions/web3';
 import { useAppSelector } from 'store/index';
 
 import { NominateContract } from './index';
@@ -15,9 +18,7 @@ jest.mock('next/navigation', () => ({
 }));
 jest.mock('next/router', () => ({
   useRouter: jest.fn().mockReturnValue({
-    router: {
-      replace: jest.fn(),
-    },
+    replace: jest.fn(),
   }),
 }));
 
@@ -159,5 +160,83 @@ describe('<NominateContract/>', () => {
 
     expect(screen.getByText(/Nominating staking contract.../)).toBeInTheDocument();
     expect(screen.getByText(/Waiting for transaction.../)).toBeInTheDocument();
+  });
+
+  // Regression tests for the runaway-transactions bug: background data refreshes
+  // recreate the nominate/switch callbacks, re-running the trigger effect. Without
+  // the ref guards (and the per-contract `key`), this fired a fresh transaction on
+  // every re-render — flooding the wallet with hundreds of signatures.
+  describe('auto-trigger guards', () => {
+    const oneContractOnMainnet = () => {
+      (useAccount as jest.Mock).mockReturnValue({ address: '0xMyAddress', chainId: mainnet.id });
+      // A fresh array/object on every render mimics Redux re-dispatching a new
+      // myStakingContracts reference from background wagmi refetches.
+      (useAppSelector as jest.Mock).mockImplementation(() => ({
+        networkDisplayName: 'Ethereum',
+        networkName: 'ethereum',
+        myStakingContracts: [{ id: '0x12345', name: 'My Staking Contract', isNominated: false }],
+      }));
+    };
+
+    it('should call addNominee only once despite repeated re-renders', async () => {
+      oneContractOnMainnet();
+
+      const { rerender } = render(<NominateContract />);
+
+      // Force re-renders, each producing a new contractInfo identity.
+      for (let i = 0; i < 5; i += 1) {
+        rerender(<NominateContract />);
+      }
+
+      await waitFor(() => expect(addNominee).toHaveBeenCalledTimes(1));
+    });
+
+    it('should attempt the network switch only once when on the wrong chain', async () => {
+      const switchChainAsync = jest.fn().mockResolvedValue(undefined);
+      (useSwitchChain as jest.Mock).mockReturnValue({ switchChainAsync });
+      // Gnosis (100), i.e. not mainnet.
+      (useAccount as jest.Mock).mockReturnValue({ address: '0xMyAddress', chainId: 100 });
+      (useAppSelector as jest.Mock).mockImplementation(() => ({
+        networkDisplayName: 'Gnosis',
+        networkName: 'gnosis',
+        myStakingContracts: [{ id: '0x12345', name: 'My Staking Contract', isNominated: false }],
+      }));
+
+      const { rerender } = render(<NominateContract />);
+      for (let i = 0; i < 5; i += 1) {
+        rerender(<NominateContract />);
+      }
+
+      await waitFor(() => expect(switchChainAsync).toHaveBeenCalledTimes(1));
+      // Still on the wrong chain, so the nominate transaction must not fire.
+      expect(addNominee).not.toHaveBeenCalled();
+    });
+
+    it('should nominate again when navigating to a different contract', async () => {
+      (useAccount as jest.Mock).mockReturnValue({ address: '0xMyAddress', chainId: mainnet.id });
+      (useAppSelector as jest.Mock).mockImplementation(() => ({
+        networkDisplayName: 'Ethereum',
+        networkName: 'ethereum',
+        myStakingContracts: [
+          { id: '0x11111', name: 'Contract A', isNominated: false },
+          { id: '0x22222', name: 'Contract B', isNominated: false },
+        ],
+      }));
+
+      let currentId = '0x11111';
+      (useParams as jest.Mock).mockImplementation(() => ({ id: currentId }));
+
+      const { rerender } = render(<NominateContract />);
+      await waitFor(() => expect(addNominee).toHaveBeenCalledTimes(1));
+      expect(addNominee).toHaveBeenLastCalledWith(expect.objectContaining({ address: '0x11111' }));
+
+      // Switch to another contract on the same route — the `key` remounts the
+      // inner component, resetting the guard so the new contract is nominated.
+      currentId = '0x22222';
+      rerender(<NominateContract />);
+
+      await waitFor(() => expect(addNominee).toHaveBeenCalledTimes(2));
+      expect(addNominee).toHaveBeenLastCalledWith(expect.objectContaining({ address: '0x22222' }));
+    });
   });
 });

--- a/apps/launch/components/NominateContract/index.tsx
+++ b/apps/launch/components/NominateContract/index.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mainnet } from 'viem/chains';
 import { useAccount, useSwitchChain } from 'wagmi';
 
@@ -45,6 +45,14 @@ const NominatedContractContent: FC<NominatedContractContentProps> = ({
   const [isSuccessful, setIsSuccessful] = useState(false);
   const [error, setError] = useState<ErrorType>(null);
 
+  // Guards so the auto-triggered network switch and nominate transaction each fire
+  // at most once. Without these, background data refreshes (e.g. wagmi reads in
+  // useGetMyStakingContracts re-dispatching myStakingContracts) recreate the
+  // callbacks below, re-running the effect and enqueuing duplicate transactions
+  // while a transaction is still awaiting signature.
+  const hasSwitchedRef = useRef(false);
+  const hasNominatedRef = useRef(false);
+
   const switchNetworkCallback = useCallback(async () => {
     try {
       setIsPending(true);
@@ -82,11 +90,21 @@ const NominatedContractContent: FC<NominatedContractContentProps> = ({
   }, [account, contractInfo, dispatch, networkName, router]);
 
   useEffect(() => {
+    if (!account) return;
+
     if (chainId !== mainnet.id) {
+      // Prompt the network switch only once; on failure we show SwitchNetworkError
+      // rather than re-prompting in a loop.
+      if (hasSwitchedRef.current) return;
+      hasSwitchedRef.current = true;
       switchNetworkCallback();
-    } else {
-      addNomineeCallback();
+      return;
     }
+
+    // On mainnet: fire the nominate transaction exactly once.
+    if (hasNominatedRef.current) return;
+    hasNominatedRef.current = true;
+    addNomineeCallback();
   }, [chainId, account, addNomineeCallback, switchNetworkCallback]);
 
   const transactionInfo = useMemo(() => {
@@ -149,8 +167,9 @@ export const NominateContract = () => {
   return (
     <Container>
       <NominatedContractContent
+        key={contractInfo.id}
         contractName={contractName}
-        contractInfo={myStakingContracts[contractIndex]}
+        contractInfo={contractInfo}
       />
     </Container>
   );


### PR DESCRIPTION
## Problem

When a user creates a staking contract on some chain and clicks **Nominate**, the page is supposed to switch them to Ethereum mainnet (where the VoteWeighting contract lives) and submit `addNomineeEVM`. Instead, the page frantically flickers and enqueues hundreds of transactions to sign.

## Root cause

`apps/launch/components/NominateContract/index.tsx` auto-fires its actions from a `useEffect`:

```js
useEffect(() => {
  if (chainId !== mainnet.id) switchNetworkCallback();
  else addNomineeCallback();
}, [chainId, account, addNomineeCallback, switchNetworkCallback]);
```

There is **no idempotency guard**, and the two callbacks are *unstable*: `addNomineeCallback` depends on `contractInfo`, which is `myStakingContracts[index]` — a freshly-allocated object that `useGetMyStakingContracts` re-dispatches into Redux on every wagmi read refetch (chain switch, new blocks, window focus, polling).

So the loop is: switch to mainnet → wagmi refetches → Redux dispatches a new array → new `contractInfo` → new `addNomineeCallback` identity → effect re-fires → **another `addNominee` write-tx**. While a transaction is still awaiting signature, the background reads keep firing the effect and piling up signatures.

## Fix

- Add `hasSwitchedRef` / `hasNominatedRef` guards so the network switch and the nominate transaction each fire **at most once** per mount, regardless of callback/dependency churn. The retry button still works (it calls the callback directly, not via the effect).
- Key the inner component by `contractInfo.id` so React remounts it — resetting the guards and state — when nominating a *different* contract (covers navigating directly between `/nominate-contract/[id]` routes, where Next.js reuses the component instance rather than remounting).

## Tests

New `auto-trigger guards` regression suite in `index.spec.tsx`:
- `addNominee` fires exactly once despite a re-render storm with new `myStakingContracts` references each render.
- Network switch is attempted once when off-mainnet, and `addNominee` doesn't fire until on mainnet.
- Re-nomination works when switching to a different contract (validates the `key` remount).

Also fixed the malformed `next/router` mock (`{ router: { replace } }` → `{ replace }`) so the post-success path doesn't crash.

All 9 tests pass (`yarn nx test launch`); lint passes.

> Note: validated via unit tests. Worth a manual end-to-end check (or by throttling the network so reads refetch mid-signing) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)