### PR TITLE
fix(govern): stop proposals page crashing on null quorum

### DIFF
--- a/apps/govern/common-util/graphql/types.ts
+++ b/apps/govern/common-util/graphql/types.ts
@@ -14,7 +14,9 @@ export type Proposal = {
   description: string;
   votesFor: string;
   votesAgainst: string;
-  quorum: string;
+  // null when the subgraph has no quorum yet (e.g. a proposal that is not
+  // finalized) and the on-chain backfill in `useProposals` could not resolve it
+  quorum: string | null;
   transactionHash: string;
   voteCasts: {
     id: string;

--- a/apps/govern/components/Proposals/utils.ts
+++ b/apps/govern/components/Proposals/utils.ts
@@ -24,9 +24,9 @@ export const VOTES_SORTED: VoteSupport[] = [
   VoteSupport.Abstain,
 ];
 
-export const formatWeiToEth = (value: string) =>
+export const formatWeiToEth = (value: string | null | undefined) =>
   formatWeiNumber({
-    value: ethers.formatUnits(value, 18),
+    value: value == null ? undefined : ethers.formatUnits(value, 18),
     maximumFractionDigits: 3,
   });
 
@@ -56,6 +56,11 @@ export const getUserVote = (proposal: Proposal, address: Address) =>
  */
 export const isQuorumReached = (proposal: Proposal) => {
   const { votesFor, quorum } = proposal;
+  // Quorum can be unavailable (e.g. a not-yet-finalized proposal whose on-chain
+  // quorum could not be backfilled). Without it we cannot confirm the quorum was
+  // reached, so treat it as not reached rather than crashing on BigInt(null).
+  if (quorum == null) return false;
+
   const votesForBigInt = BigInt(votesFor);
   const quorumBigInt = BigInt(quorum);
 

--- a/apps/govern/hooks/useProposals.ts
+++ b/apps/govern/hooks/useProposals.ts
@@ -13,7 +13,10 @@ import { getProposals } from 'common-util/graphql/queries';
 import { useAppSelector } from 'store/index';
 
 export const useProposals = () => {
-  const { data: block, isLoading: isBlockLoading } = useBlock();
+  // Proposals' startBlock/endBlock and GovernorOLAS live on mainnet, so the
+  // current block used for status/quorum comparisons must come from mainnet too
+  // (otherwise a non-mainnet wallet yields meaningless block-number comparisons).
+  const { data: block, isLoading: isBlockLoading } = useBlock({ chainId: mainnet.id });
   const { proposalVotes } = useAppSelector((state) => state.govern);
 
   const { data: proposals, isLoading: isProposalsLoading } = useQuery({
@@ -62,7 +65,7 @@ export const useProposals = () => {
         // update the result with quorums
         return proposals.proposalCreateds.map((item) => ({
           ...item,
-          quorum: item.quorum || quorumByProposalId[item.proposalId],
+          quorum: item.quorum || quorumByProposalId[item.proposalId] || null,
         }));
       }
 


### PR DESCRIPTION
## Problem

The Govern proposals page white-screens with:

```
TypeError: Cannot convert undefined to a BigInt
    at isQuorumReached (...)
```

## Why it happens

The crash is triggered by a **legacy Defeated proposal that has no quorum value**:

- The subgraph has **no quorum record** for it (quorum is only written when a proposal is queued/executed/cancelled — this one never was).
- We **no longer estimate its quorum on-chain**, because it was created on the **old governor contract** which has since been replaced. The current `GovernorOLAS` returns `0` for that proposal's snapshot block (its quorum-numerator checkpoint history doesn't reach back that far), so an on-chain read can't recover a meaningful value either.

We deliberately **do not special-case backfilling** this — it's legacy and the proposal is Defeated anyway, so the exact quorum figure is irrelevant. The subgraph will be updated separately in the future to record quorum for these proposals.

Until then, the UI simply must not crash when `quorum` is null. Today it calls `BigInt(quorum)` / `ethers.formatUnits(quorum)` on the null value and takes the whole list down.

## Fix — make the render path null-safe

1. `common-util/graphql/types.ts` — type `quorum` as `string | null` (matches reality; it can legitimately be absent).
2. `components/Proposals/utils.ts`:
   - `isQuorumReached` returns `false` when `quorum == null` instead of `BigInt(null)`. The proposal renders as **Defeated**, which is correct for this legacy proposal.
   - `formatWeiToEth` is null-safe, so the Quorum column renders `0` instead of throwing in `ethers.formatUnits`.
3. `hooks/useProposals.ts`:
   - Normalize the on-chain backfill fallback to `null` (not `undefined`) so the value satisfies the type.
   - Pin `useBlock({ chainId: mainnet.id })` — proposal `startBlock`/`endBlock` and `GovernorOLAS` are on mainnet, so a non-mainnet wallet otherwise yields meaningless block-number comparisons for status.

## Testing

- `yarn nx lint govern` — clean (only a pre-existing unrelated `<img>` warning).
- `npx tsc --noEmit -p apps/govern/tsconfig.json` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1192" height="252" alt="image" src="https://github.com/user-attachments/assets/ba947343-d27f-45b7-a707-4bb09e9d5483" />
