### PR TITLE
feat(operate): enable Basius I/II/III staking contracts on pearl

### DIFF
--- a/apps/operate/common-util/constants/contracts.ts
+++ b/apps/operate/common-util/constants/contracts.ts
@@ -148,6 +148,18 @@ export const STAKING_CONTRACT_DETAILS: Record<Address, StakingContractDetailsInf
   '0x0000000000000000000000001f81cf353051daa8919d1777c58b667025794ddc': {
     availableOn: ['lst'],
   },
+  // Basius I
+  '0x0000000000000000000000000fb55cef7b12b76ea52900325461a5443f51b43f': {
+    availableOn: ['pearl'],
+  },
+  // Basius II
+  '0x000000000000000000000000728ca3b024ba4c273695df6e45e79db675b8c756': {
+    availableOn: ['pearl'],
+  },
+  // Basius III
+  '0x0000000000000000000000009593c4524df86f46935aa0ec996b4ccbe71c8234': {
+    availableOn: ['pearl'],
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Enable three new Basius staking contracts on the **pearl** platform in the Operate app.

| Name | Address |
|------|---------|
| Basius I | `0x0fB55CEf7B12B76ea52900325461a5443F51B43F` |
| Basius II | `0x728ca3b024Ba4c273695Df6e45e79DB675B8c756` |
| Basius III | `0x9593C4524DF86f46935aa0eC996B4ccBe71c8234` |

Each is added to `STAKING_CONTRACT_DETAILS` in `apps/operate/common-util/constants/contracts.ts` with the addresses zero-padded to 32 bytes and lowercased, matching the existing entries. `pearl` is an existing platform, so no platform wiring changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1487" height="290" alt="image" src="https://github.com/user-attachments/assets/a7e5c9d7-474f-4525-b36d-a37f5fc135cc" />
