### PR TITLE
feat: [BDMARK-2212] enable new staking contracts + heal poisoned contract cache

### DIFF
--- a/apps/govern/common-util/blob/contract-cache.ts
+++ b/apps/govern/common-util/blob/contract-cache.ts
@@ -2,7 +2,11 @@ import { list, put } from '@vercel/blob';
 
 import type { GovernContractCacheData, GovernContractCacheSnapshot } from 'types';
 
-const BLOB_PREFIX = 'govern/contracts';
+// Versioned prefix. Bump when the cached snapshot shape or the rules for what may be cached
+// change, so stale snapshots are treated as misses and repopulated. v2 invalidates snapshots
+// poisoned by transient RPC failures at population time (empty name / configHash / proxyHash /
+// activityChecker) written before the completeness guard in fetchContractCacheDataFromChain.
+const BLOB_PREFIX = 'govern/contracts/v2';
 
 function blobPath(chainId: number, address: string): string {
   return `${BLOB_PREFIX}/${chainId}/${address.toLowerCase()}.json`;

--- a/apps/govern/common-util/fetch-contract-cache-data.ts
+++ b/apps/govern/common-util/fetch-contract-cache-data.ts
@@ -107,17 +107,22 @@ export async function fetchContractCacheDataFromChain(
       client.readContract({ ...contractArgs, functionName: 'metadataHash' }),
     ]);
 
-    const hasValidKeyCall =
-      maxNumServicesRes.status === 'fulfilled' ||
-      metadataHashRes.status === 'fulfilled' ||
-      configHashRes.status === 'fulfilled' ||
-      proxyHashRes.status === 'fulfilled';
-    if (!hasValidKeyCall) {
+    // All identity/config reads must succeed before we cache a snapshot. A failed read means
+    // either a non-staking address or a transient RPC error — in both cases caching is wrong.
+    // (Previously a failed `metadataHash` read was coerced to ZERO_HASH via `toMetadataHashString`,
+    // which bypassed the empty-metadata guard below and permanently poisoned the cache with an
+    // empty name/description and empty configHash/proxyHash/activityChecker. Because the
+    // write-through cache only fetches on a miss, that bad snapshot was then served forever.)
+    if (
+      metadataHashRes.status !== 'fulfilled' ||
+      configHashRes.status !== 'fulfilled' ||
+      proxyHashRes.status !== 'fulfilled' ||
+      activityCheckerRes.status !== 'fulfilled'
+    ) {
       return null;
     }
 
-    const rawMetadataHash = settled(metadataHashRes, null);
-    const metadataHashStr = toMetadataHashString(rawMetadataHash);
+    const metadataHashStr = toMetadataHashString(metadataHashRes.value);
     const meta = await fetchMetadata(metadataHashStr);
 
     // Do not cache when metadata was expected but fetch failed (empty name/description)

--- a/apps/operate/common-util/constants/contracts.ts
+++ b/apps/operate/common-util/constants/contracts.ts
@@ -160,6 +160,58 @@ export const STAKING_CONTRACT_DETAILS: Record<Address, StakingContractDetailsInf
   '0x0000000000000000000000009593c4524df86f46935aa0ec996b4ccbe71c8234': {
     availableOn: ['pearl'],
   },
+  // Omenstrat I
+  '0x0000000000000000000000001e215da0541b4a77a66e21f17413a877b84ab129': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat II
+  '0x000000000000000000000000c2bbfc0d2f5a341dcdcc9f3b78faf7b04f0244ff': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat III
+  '0x000000000000000000000000abd4f159a088e7f18fee8241cf9367f1d746780f': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat IV
+  '0x000000000000000000000000c9940b9daca9fdf1b0cd6de8e3d25dddc8c9fd0d': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat V
+  '0x00000000000000000000000093aaa7155942700cad74c250263fb2d0c6f72b27': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat VI
+  '0x000000000000000000000000b7ab6f7e6993df1f0c6a9b177b169faf4b0c9cca': {
+    availableOn: ['pearl'],
+  },
+  // Omenstrat VII
+  '0x000000000000000000000000b801fd1728eef27418fe03720b1ff3e769f35152': {
+    availableOn: ['pearl'],
+  },
+  // Optimus I
+  '0x000000000000000000000000cda7deef16f6b1bfc1bb5c89b7e4faa91d9ebf7b': {
+    availableOn: ['pearl'],
+  },
+  // Optimus II
+  '0x000000000000000000000000746281b8fbdbd008729dc9382392810f771b1bfd': {
+    availableOn: ['pearl'],
+  },
+  // Optimus III
+  '0x0000000000000000000000005a4317a5695ad6e86744efc824414cf899f07c68': {
+    availableOn: ['pearl'],
+  },
+  // Polystrat I
+  '0x00000000000000000000000035c9c87a8cad9b7fd9d367eb4fd287365688e000': {
+    availableOn: ['pearl'],
+  },
+  // Polystrat II
+  '0x000000000000000000000000d7f69649691039e86f15153c7bd567aa0049d122': {
+    availableOn: ['pearl'],
+  },
+  // Polystrat III
+  '0x0000000000000000000000007dbf10769ca7528ec9aa440b668c716caf08e7ea': {
+    availableOn: ['pearl'],
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Two related changes that came out of investigating why Base staking contracts wouldn't load on their individual govern pages.

### 1. `feat(operate)` — enable new staking contracts on Pearl
Re-enables the new staking-mechanism contracts for all agents (mirrors [olas-operate-app#2039](https://github.com/valory-xyz/olas-operate-app/pull/2039)):

- **Omenstrat I–VII** (Gnosis)
- **Optimus I–III** (Optimism)
- **Polystrat I–III** (Polygon)

All 13 are already registered as nominees in `VoteWeighting` (verified on-chain via `getAllNominees`), so adding them to `STAKING_CONTRACT_DETAILS` with `availableOn: ['pearl']` is sufficient to surface them under the Pearl filter — no `EXTRA_STAKING_CONTRACTS` entry needed.

### 2. `fix(govern)` — heal poisoned contract cache (Base contracts not loading)
Individual contract pages (e.g. [Basius I on Base](https://govern.olas.network/contracts/0x0000000000000000000000000fb55cef7b12b76ea52900325461a5443f51b43f)) rendered with an **empty name/description** and missing config fields.

**Root cause:** the server-side blob cache snapshot was poisoned at population time. `fetchContractCacheDataFromChain` reads via `Promise.allSettled`, and a transient `metadataHash` read failure was coerced to `ZERO_HASH`, which bypassed the "don't cache empty metadata" guard. The bad snapshot (empty name / `configHash` / `proxyHash` / `activityChecker`) was then served permanently, because the write-through cache only fetches on a miss. All those fields read fine on-chain now — it was a stale, poisoned cache.

**Fix:**
- `fetch-contract-cache-data.ts`: require `metadataHash`/`configHash`/`proxyHash`/`activityChecker` reads to all succeed before caching. A failed read is now treated as transient (return `null`, retry) instead of being cached as empty — prevents future poisoning.
- `contract-cache.ts`: bump blob prefix to `govern/contracts/v2` so existing poisoned snapshots become misses and self-heal (repopulate cleanly) on next load. Covers both the per-contract and batch endpoints.

The operate app uses `Promise.all` (any failed read throws → never caches), so it has no equivalent poisoning.

## Verification
- Verified all 13 new contracts are on-chain nominees.
- Reproduced the empty-name Base page against production; compared good vs poisoned cache snapshots to isolate the `proxyHash`/`activityChecker` = `""` signature.
- Confirmed all contract fields are readable on-chain now (proving stale cache, not unsupported functions).
- `yarn nx lint operate` and `yarn nx lint govern` pass.

## Deploy / Vercel notes
- The govern fix takes effect on deploy; the `v2` cache repopulates on first access (one-time write-through, bounded by the existing concurrency limit).
- Requires the existing `GOVERN_BLOB_READ_WRITE_TOKEN` env var (already configured in prod) for the cache writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Preview verification note

Verifying the govern fix on a **Preview** deployment requires **non-test RPCs** (or a freshly-pinned Tenderly mainnet fork).

The govern Preview scope runs with `NEXT_PUBLIC_IS_CONNECTED_TO_TEST_NET=true`, which routes mainnet through a Tenderly virtual-testnet fork. The contracts list is built from `getAllNominees()` on **mainnet**, so if that fork is **stale/expired** (pinned to a block before Basius was registered as a nominee, or returning `400`), the new Base contracts simply aren't in the nominee list the preview reads → **"Contract not found"**. This is an environment artifact, not the cache bug.

To verify properly:
- **Easiest:** test on **production** after merge — real RPCs → Basius is a nominee → the `v2` cache repopulates from a successful read → name + full config render.
- **Or on Preview:** set `NEXT_PUBLIC_IS_CONNECTED_TO_TEST_NET=false` for the govern Preview scope, **or** refresh the Tenderly forks (`NEXT_PUBLIC_MAINNET_TEST_RPC`, `NEXT_PUBLIC_GNOSIS_TEST_RPC`, `NEXT_PUBLIC_POLYGON_TEST_RPC`, `NEXT_PUBLIC_MODE_TEST_RPC`) to recent blocks, then redeploy.

(Base reads aren't forked — chain `8453` always hits real Base — so once the **mainnet** nominee source is current, the Base contract page resolves normally.)
