### PR TITLE
feat(govern): [BDMARK-2218] governor contract in proposals footer + queued execution ETA

### DIFF
--- a/apps/govern/CLAUDE.md
+++ b/apps/govern/CLAUDE.md
@@ -61,6 +61,17 @@ Individual on-chain proposals are shareable via `/proposals?proposalId=<proposal
 - `components/Proposals/ProposalDetails.tsx` exposes a **Copy link** button that writes the absolute URL to the clipboard.
 - SEO: `/proposals?proposalId=...` is a deep-link variant of `/proposals`, not a distinct page. `components/Meta.tsx` emits `<link rel="canonical">` from `pageUrl` (query-string-free), so query-param variants consolidate onto the canonical `/proposals` URL instead of being flagged as duplicate titles.
 
+## Proposal execution ETA
+
+A queued proposal sits in the timelock until it can be executed:
+
+- `hooks/useProposalEta.ts` reads `GovernorOLAS.proposalEta(proposalId)` (mainnet), which returns the executable timestamp (0 when not queued). It's only enabled while a proposal is queued (`isQueued && !isExecuted && !isCancelled`).
+- `components/Proposals/ProposalDetails.tsx` shows an **Executable** field for queued proposals: the full date plus the time remaining (`in 1d 2h 3m`, or `ready to execute` once the ETA has passed), formatted via `formatDuration` in `common-util/functions/time.ts`.
+
+## Footer contracts (per tab)
+
+`components/Layout/Footer/index.tsx` shows different contract links depending on the route: the **/proposals** page links **GovernorOLAS** + veOLAS, while the other (voting) tabs link **VoteWeighting** + veOLAS.
+
 ## Notes
 
 - Voting and delegation logic depends on governor contracts and subgraph; ensure correct chain and subgraph URL.

--- a/apps/govern/common-util/functions/time.ts
+++ b/apps/govern/common-util/functions/time.ts
@@ -108,6 +108,26 @@ export const getRemainingTimeInSeconds = (unlockTime?: number) => {
 };
 
 /**
+ * Formats a duration (in seconds) into a short human-readable string,
+ * e.g. 90061 => "1d 1h 1m". Returns null for non-positive durations.
+ */
+export const formatDuration = (seconds: number): string | null => {
+  if (seconds <= 0) return null;
+
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  // Always show minutes when there are no days, so very short durations aren't empty
+  if (minutes > 0 || days === 0) parts.push(`${minutes}m`);
+
+  return parts.join(' ');
+};
+
+/**
  * Returns estimated time in future based on provided block
  */
 export const estimateFutureBlockTimestamp = (

--- a/apps/govern/components/Layout/Footer/index.tsx
+++ b/apps/govern/components/Layout/Footer/index.tsx
@@ -1,37 +1,61 @@
 import { Typography } from 'antd';
 import { Fragment } from 'react';
+import { Address } from 'viem';
 import { mainnet } from 'viem/chains';
+import { useRouter } from 'next/router';
 
 import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
 import { EXPLORER_URLS, GOVERN_REPO_URL } from 'libs/util-constants/src';
-import { VE_OLAS, VOTE_WEIGHTING } from 'libs/util-contracts/src/lib/abiAndAddresses';
+import {
+  GOVERNOR_OLAS,
+  VE_OLAS,
+  VOTE_WEIGHTING,
+} from 'libs/util-contracts/src/lib/abiAndAddresses';
 
 import { Onboarding } from './Onboarding';
 
-const contracts = [
-  {
-    name: 'VoteWeighting',
-    link: `${EXPLORER_URLS[mainnet.id]}/address/${VOTE_WEIGHTING.addresses[mainnet.id]}`,
-  },
-  {
-    name: 'veOLAS',
-    link: `${EXPLORER_URLS[mainnet.id]}/address/${VE_OLAS.addresses[mainnet.id]}`,
-  },
-];
+const veOlasContract = {
+  name: 'veOLAS',
+  link: `${EXPLORER_URLS[mainnet.id]}/address/${VE_OLAS.addresses[mainnet.id]}`,
+};
 
-const LeftContent = () => (
-  <Typography.Text type="secondary">
-    {`Contracts: `}
-    {contracts.map((item, index) => (
-      <Fragment key={index}>
-        {index !== 0 && ' • '}
-        <a href={item.link} target="_blank" rel="noopener noreferrer">
-          {item.name}
-        </a>
-      </Fragment>
-    ))}
-  </Typography.Text>
-);
+const voteWeightingContract = {
+  name: 'VoteWeighting',
+  link: `${EXPLORER_URLS[mainnet.id]}/address/${VOTE_WEIGHTING.addresses[mainnet.id]}`,
+};
+
+const governorContract = {
+  name: 'GovernorOLAS',
+  link: `${EXPLORER_URLS[mainnet.id]}/address/${
+    (GOVERNOR_OLAS.addresses as Record<number, Address>)[mainnet.id]
+  }`,
+};
+
+// On the proposals page the governor contract is the relevant one;
+// VoteWeighting is relevant for the other (voting) tabs.
+const getContracts = (pathname: string) =>
+  pathname === '/proposals'
+    ? [governorContract, veOlasContract]
+    : [voteWeightingContract, veOlasContract];
+
+const LeftContent = () => {
+  const { pathname } = useRouter();
+  const contracts = getContracts(pathname);
+
+  return (
+    <Typography.Text type="secondary">
+      {`Contracts: `}
+      {contracts.map((item, index) => (
+        <Fragment key={index}>
+          {index !== 0 && ' • '}
+          <a href={item.link} target="_blank" rel="noopener noreferrer">
+            {item.name}
+          </a>
+        </Fragment>
+      ))}
+    </Typography.Text>
+  );
+};
 
 export const Footer = () => (
   <>

--- a/apps/govern/components/Proposals/ProposalDetails.tsx
+++ b/apps/govern/components/Proposals/ProposalDetails.tsx
@@ -8,8 +8,13 @@ import { Caption } from 'libs/ui-components/src';
 import { areAddressesEqual, notifySuccess } from 'libs/util-functions/src';
 import { AddressLink } from 'libs/ui-components/src';
 
-import { estimateFutureBlockTimestamp, getFullFormattedDate } from 'common-util/functions';
+import {
+  estimateFutureBlockTimestamp,
+  formatDuration,
+  getFullFormattedDate,
+} from 'common-util/functions';
 import { Proposal } from 'common-util/graphql/types';
+import { useProposalEta } from 'hooks/useProposalEta';
 
 import { VOTES_SUPPORT, formatWeiToEth } from './utils';
 import { EXPLORER_URLS, NA, UNICODE_SYMBOLS } from 'libs/util-constants/src';
@@ -50,6 +55,12 @@ export const ProposalDetails = ({
   const startDateBlock = useBlockTimestamp(currentBlock, BigInt(item.startBlock));
   const endDateBlock = useBlockTimestamp(currentBlock, BigInt(item.endBlock));
 
+  // A queued proposal sits in the timelock until its ETA, after which it can be executed.
+  const isWaitingToExecute = item.isQueued && !item.isExecuted && !item.isCancelled;
+  const { eta, isLoading: isEtaLoading } = useProposalEta(item.proposalId, isWaitingToExecute);
+  const secondsUntilExecutable = eta ? Number(eta) - Math.floor(Date.now() / 1000) : 0;
+  const timeUntilExecutable = formatDuration(secondsUntilExecutable);
+
   const handleCopyLink = () => {
     const url = `${window.location.origin}/proposals?proposalId=${item.proposalId}`;
     navigator.clipboard.writeText(url);
@@ -78,6 +89,19 @@ export const ProposalDetails = ({
             <Text>{getFullFormattedDate(Number(endDateBlock.timestamp) * 1000)}</Text>
           )}
         </Flex>
+        {isWaitingToExecute && (
+          <Flex vertical>
+            <Caption>Executable</Caption>
+            {isEtaLoading && <Skeleton.Input active />}
+            {!isEtaLoading && eta && (
+              <Text>
+                {getFullFormattedDate(Number(eta) * 1000)}
+                {timeUntilExecutable ? ` (in ${timeUntilExecutable})` : ' (ready to execute)'}
+              </Text>
+            )}
+            {!isEtaLoading && !eta && NA}
+          </Flex>
+        )}
       </Flex>
       <Flex vertical gap={8} className="mb-16">
         <Caption>Voters ({item.voteCasts?.length})</Caption>

--- a/apps/govern/hooks/useProposalEta.ts
+++ b/apps/govern/hooks/useProposalEta.ts
@@ -12,7 +12,7 @@ import { GOVERNOR_OLAS } from 'libs/util-contracts/src/lib/abiAndAddresses';
  * (i.e. queued but not yet executed/cancelled); `enabled` should reflect that.
  */
 export const useProposalEta = (proposalId: string, enabled: boolean) => {
-  const { data, isLoading } = useReadContract({
+  const { data, isLoading, isError } = useReadContract({
     address: (GOVERNOR_OLAS.addresses as Record<number, Address>)[mainnet.id],
     abi: GOVERNOR_OLAS.abi as Abi,
     functionName: 'proposalEta',
@@ -20,6 +20,11 @@ export const useProposalEta = (proposalId: string, enabled: boolean) => {
     args: [BigInt(proposalId)],
     query: {
       enabled,
+      // Don't retry: the call either succeeds quickly or fails deterministically
+      // (e.g. on a forked/preview mainnet RPC that lacks this proposal's timelock
+      // state, `proposalEta` returns empty data). Retrying would leave the UI
+      // stuck on a loading skeleton instead of settling to a fallback.
+      retry: false,
     },
   });
 
@@ -30,5 +35,6 @@ export const useProposalEta = (proposalId: string, enabled: boolean) => {
     // executable timestamp in seconds, or undefined when not queued/unavailable
     eta: eta && eta > 0n ? eta : undefined,
     isLoading,
+    isError,
   };
 };

--- a/apps/govern/hooks/useProposalEta.ts
+++ b/apps/govern/hooks/useProposalEta.ts
@@ -1,0 +1,34 @@
+import { Abi, Address } from 'viem';
+import { mainnet } from 'viem/chains';
+import { useReadContract } from 'wagmi';
+
+import { GOVERNOR_OLAS } from 'libs/util-contracts/src/lib/abiAndAddresses';
+
+/**
+ * Returns the timestamp (in seconds) at which a queued proposal becomes
+ * executable, read from `GovernorOLAS.proposalEta(proposalId)`.
+ *
+ * The ETA is only meaningful while the proposal sits in the timelock queue
+ * (i.e. queued but not yet executed/cancelled); `enabled` should reflect that.
+ */
+export const useProposalEta = (proposalId: string, enabled: boolean) => {
+  const { data, isLoading } = useReadContract({
+    address: (GOVERNOR_OLAS.addresses as Record<number, Address>)[mainnet.id],
+    abi: GOVERNOR_OLAS.abi as Abi,
+    functionName: 'proposalEta',
+    chainId: mainnet.id,
+    args: [BigInt(proposalId)],
+    query: {
+      enabled,
+    },
+  });
+
+  // `proposalEta` returns 0 when the proposal is not in the timelock queue.
+  const eta = data ? BigInt(data as string | bigint) : undefined;
+
+  return {
+    // executable timestamp in seconds, or undefined when not queued/unavailable
+    eta: eta && eta > 0n ? eta : undefined,
+    isLoading,
+  };
+};


### PR DESCRIPTION
## What

Two changes to the **Govern** app's Proposals tab:

1. **Footer shows the governor contract on /proposals.** The footer contract links are now route-aware: the `/proposals` page links **GovernorOLAS** + veOLAS, while the other (voting) tabs keep linking **VoteWeighting** + veOLAS (VoteWeighting is relevant there, not on proposals).

2. **Time until a queued proposal can be executed.** Queued proposals sit in the timelock until their ETA. The expanded proposal details now show an **Executable** field with the full date plus the time remaining (`in 1d 2h 3m`, or `ready to execute` once the ETA has passed).

## How

- `components/Layout/Footer/index.tsx` — picks contracts by `useRouter().pathname`.
- `hooks/useProposalEta.ts` (new) — reads `GovernorOLAS.proposalEta(proposalId)` on mainnet; only enabled while a proposal is queued (`isQueued && !isExecuted && !isCancelled`). Returns `0` when not queued.
- `common-util/functions/time.ts` — new `formatDuration` helper (seconds → `1d 2h 3m`).
- `components/Proposals/ProposalDetails.tsx` — renders the **Executable** field for queued proposals (skeleton while loading, `N/A` if the ETA can't be resolved).
- `apps/govern/CLAUDE.md` — documented both changes.

## Notes

- The "time remaining" is computed at render time (no live countdown) — consistent with the existing date fields in this view.
- The ETA is shown in the expanded **ProposalDetails** rather than the width-constrained Status column. Can move/duplicate it inline next to the "Queued" tag if preferred.

## Testing

`yarn nx lint govern` passes. Best verified on the Vercel preview deploy (Proposals tab footer + expanding a queued proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)