### PR TITLE
pearl-api: add HU and PT to polymarket_trader restricted countries

### DIFF
--- a/apps/pearl-api/pages/api/geo/agent-eligibility.ts
+++ b/apps/pearl-api/pages/api/geo/agent-eligibility.ts
@@ -53,6 +53,7 @@ const AGENT_POLICIES: Record<AgentId, AgentPolicy> = {
       'FR', // France
       'GB', // United Kingdom
       'GW', // Guinea-Bissau
+      'HU', // Hungary
       'IR', // Iran
       'IQ', // Iraq
       'IT', // Italy
@@ -64,6 +65,7 @@ const AGENT_POLICIES: Record<AgentId, AgentPolicy> = {
       'NI', // Nicaragua
       'NL', // Netherlands
       'PL', // Poland
+      'PT', // Portugal
       'RU', // Russia
       'SD', // Sudan
       'SG', // Singapore


### PR DESCRIPTION
Aligns the agent eligibility policy with Polymarket's own geographic restrictions, which added Hungary and Portugal in January 2026. Two country-code additions, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)