### PR TITLE
operate/build: hedge meta wording and add site notice

### DIFF
--- a/apps/build/components/Layout/Footer.tsx
+++ b/apps/build/components/Layout/Footer.tsx
@@ -1,8 +1,31 @@
+import styled from 'styled-components';
+
 import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
 import { BUILD_REPO_URL } from 'libs/util-constants/src';
 
+const RegulatoryNotice = styled.div`
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 24px 24px;
+  font-size: 12px;
+  color: #949494;
+  text-align: center;
+`;
+
 const Footer = () => (
-  <CommonFooter centerContent={<FooterCenterContent />} githubUrl={BUILD_REPO_URL} />
+  <>
+    <CommonFooter centerContent={<FooterCenterContent />} githubUrl={BUILD_REPO_URL} />
+    <RegulatoryNotice>
+      This site has not been reviewed or approved by any competent authority in any Member State
+      of the European Union. Site content is set by the Olas DAO and hosted on its behalf by the
+      site operator — see the{' '}
+      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+        Disclaimer
+      </a>
+      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
+      amount invested.
+    </RegulatoryNotice>
+  </>
 );
 
 export default Footer;

--- a/apps/build/components/Layout/Footer.tsx
+++ b/apps/build/components/Layout/Footer.tsx
@@ -1,7 +1,10 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
-import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
-import { BUILD_REPO_URL } from 'libs/util-constants/src';
+import {
+  Footer as CommonFooter,
+  FooterCenterContent,
+} from "libs/ui-components/src";
+import { BUILD_REPO_URL } from "libs/util-constants/src";
 
 const RegulatoryNotice = styled.div`
   max-width: 880px;
@@ -14,16 +17,23 @@ const RegulatoryNotice = styled.div`
 
 const Footer = () => (
   <>
-    <CommonFooter centerContent={<FooterCenterContent />} githubUrl={BUILD_REPO_URL} />
+    <CommonFooter
+      centerContent={<FooterCenterContent />}
+      githubUrl={BUILD_REPO_URL}
+    />
     <RegulatoryNotice>
-      This site has not been reviewed or approved by any competent authority in any Member State
-      of the European Union. Site content is set by the Olas DAO and hosted on its behalf by the
-      site operator — see the{' '}
-      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+      This site has not been reviewed or approved by any competent authority in
+      any Member State of the European Union. Site content is set by the Olas
+      DAO and hosted on its behalf by the site operator — see the{" "}
+      <a
+        href="https://olas.network/disclaimer"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Disclaimer
       </a>
-      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
-      amount invested.
+      . OLAS is a crypto-asset: its value can go down as well as up and you may
+      lose the entire amount invested.
     </RegulatoryNotice>
   </>
 );

--- a/apps/build/components/Layout/Footer.tsx
+++ b/apps/build/components/Layout/Footer.tsx
@@ -1,10 +1,7 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
-import {
-  Footer as CommonFooter,
-  FooterCenterContent,
-} from "libs/ui-components/src";
-import { BUILD_REPO_URL } from "libs/util-constants/src";
+import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
+import { BUILD_REPO_URL } from 'libs/util-constants/src';
 
 const RegulatoryNotice = styled.div`
   max-width: 880px;
@@ -17,23 +14,16 @@ const RegulatoryNotice = styled.div`
 
 const Footer = () => (
   <>
-    <CommonFooter
-      centerContent={<FooterCenterContent />}
-      githubUrl={BUILD_REPO_URL}
-    />
+    <CommonFooter centerContent={<FooterCenterContent />} githubUrl={BUILD_REPO_URL} />
     <RegulatoryNotice>
-      This site has not been reviewed or approved by any competent authority in
-      any Member State of the European Union. Site content is set by the Olas
-      DAO and hosted on its behalf by the site operator — see the{" "}
-      <a
-        href="https://olas.network/disclaimer"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      This site has not been reviewed or approved by any competent authority in any Member State of
+      the European Union. Site content is set by the Olas DAO and hosted on its behalf by the site
+      operator — see the{' '}
+      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
         Disclaimer
       </a>
-      . OLAS is a crypto-asset: its value can go down as well as up and you may
-      lose the entire amount invested.
+      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
+      amount invested.
     </RegulatoryNotice>
   </>
 );

--- a/apps/build/components/Meta.tsx
+++ b/apps/build/components/Meta.tsx
@@ -1,9 +1,9 @@
-import Head from "next/head";
+import Head from 'next/head';
 
-const SITE_TITLE = "Build | Olas";
+const SITE_TITLE = 'Build | Olas';
 const SITE_DESCRIPTION =
-  "Explore paths to build on Olas and contribute code. Builders may earn OLAS rewards when developer incentives are active.";
-const SITE_URL = "https://build.olas.network/";
+  'Explore paths to build on Olas and contribute code. Builders may earn OLAS rewards when developer incentives are active.';
+const SITE_URL = 'https://build.olas.network/';
 const SITE_DEFAULT_IMAGE_URL = `${SITE_URL}images/metatags-image.png`;
 
 type MetaProps = {
@@ -14,7 +14,7 @@ type MetaProps = {
 
 const Meta = ({ title, description, path }: MetaProps) => {
   const pageTitle = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
-  const pageUrl = `${SITE_URL}${path || ""}`;
+  const pageUrl = `${SITE_URL}${path || ''}`;
 
   return (
     <Head>
@@ -28,19 +28,13 @@ const Meta = ({ title, description, path }: MetaProps) => {
       <meta property="og:type" content="website" />
       <meta property="og:url" content={pageUrl} />
       <meta property="og:title" content={pageTitle} />
-      <meta
-        property="og:description"
-        content={description || SITE_DESCRIPTION}
-      />
+      <meta property="og:description" content={description || SITE_DESCRIPTION} />
       <meta property="og:image" content={SITE_DEFAULT_IMAGE_URL} />
 
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content={pageUrl} />
       <meta property="twitter:title" content={pageTitle} />
-      <meta
-        property="twitter:description"
-        content={description || SITE_DESCRIPTION}
-      />
+      <meta property="twitter:description" content={description || SITE_DESCRIPTION} />
       <meta property="twitter:image" content={SITE_DEFAULT_IMAGE_URL} />
     </Head>
   );

--- a/apps/build/components/Meta.tsx
+++ b/apps/build/components/Meta.tsx
@@ -1,9 +1,9 @@
-import Head from 'next/head';
+import Head from "next/head";
 
-const SITE_TITLE = 'Build | Olas';
+const SITE_TITLE = "Build | Olas";
 const SITE_DESCRIPTION =
-  'Explore paths to build on Olas and contribute code. Builders may earn OLAS rewards when developer incentives are active.';
-const SITE_URL = 'https://build.olas.network/';
+  "Explore paths to build on Olas and contribute code. Builders may earn OLAS rewards when developer incentives are active.";
+const SITE_URL = "https://build.olas.network/";
 const SITE_DEFAULT_IMAGE_URL = `${SITE_URL}images/metatags-image.png`;
 
 type MetaProps = {
@@ -14,7 +14,7 @@ type MetaProps = {
 
 const Meta = ({ title, description, path }: MetaProps) => {
   const pageTitle = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
-  const pageUrl = `${SITE_URL}${path || ''}`;
+  const pageUrl = `${SITE_URL}${path || ""}`;
 
   return (
     <Head>
@@ -28,13 +28,19 @@ const Meta = ({ title, description, path }: MetaProps) => {
       <meta property="og:type" content="website" />
       <meta property="og:url" content={pageUrl} />
       <meta property="og:title" content={pageTitle} />
-      <meta property="og:description" content={description || SITE_DESCRIPTION} />
+      <meta
+        property="og:description"
+        content={description || SITE_DESCRIPTION}
+      />
       <meta property="og:image" content={SITE_DEFAULT_IMAGE_URL} />
 
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content={pageUrl} />
       <meta property="twitter:title" content={pageTitle} />
-      <meta property="twitter:description" content={description || SITE_DESCRIPTION} />
+      <meta
+        property="twitter:description"
+        content={description || SITE_DESCRIPTION}
+      />
       <meta property="twitter:image" content={SITE_DEFAULT_IMAGE_URL} />
     </Head>
   );

--- a/apps/build/components/Meta.tsx
+++ b/apps/build/components/Meta.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 
 const SITE_TITLE = 'Build | Olas';
 const SITE_DESCRIPTION =
-  'Explore paths to build on Olas. Simplify your path to contributing and earning OLAS rewards.';
+  'Explore paths to build on Olas and contribute code. Builders may earn OLAS rewards when developer incentives are active.';
 const SITE_URL = 'https://build.olas.network/';
 const SITE_DEFAULT_IMAGE_URL = `${SITE_URL}images/metatags-image.png`;
 

--- a/apps/operate/components/Layout/Footer.tsx
+++ b/apps/operate/components/Layout/Footer.tsx
@@ -1,25 +1,19 @@
-import { Typography } from "antd";
-import { Fragment } from "react";
-import styled from "styled-components";
-import { mainnet } from "viem/chains";
+import { Typography } from 'antd';
+import { Fragment } from 'react';
+import styled from 'styled-components';
+import { mainnet } from 'viem/chains';
 
-import {
-  Footer as CommonFooter,
-  FooterCenterContent,
-} from "libs/ui-components/src";
-import { EXPLORER_URLS, OPERATE_REPO_URL } from "libs/util-constants/src";
-import {
-  STAKING_FACTORY,
-  VOTE_WEIGHTING,
-} from "libs/util-contracts/src/lib/abiAndAddresses";
+import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
+import { EXPLORER_URLS, OPERATE_REPO_URL } from 'libs/util-constants/src';
+import { STAKING_FACTORY, VOTE_WEIGHTING } from 'libs/util-contracts/src/lib/abiAndAddresses';
 
 const contracts = [
   {
-    name: "VoteWeighting",
+    name: 'VoteWeighting',
     link: `${EXPLORER_URLS[mainnet.id]}/address/${VOTE_WEIGHTING.addresses[mainnet.id]}`,
   },
   {
-    name: "StakingFactory",
+    name: 'StakingFactory',
     link: `${EXPLORER_URLS[mainnet.id]}/address/${STAKING_FACTORY.addresses[mainnet.id]}`,
   },
 ];
@@ -29,7 +23,7 @@ const LeftContent = () => (
     {`Contracts: `}
     {contracts.map((item, index) => (
       <Fragment key={index}>
-        {index !== 0 && " • "}
+        {index !== 0 && ' • '}
         <a href={item.link} target="_blank" rel="noopener noreferrer">
           {item.name}
         </a>
@@ -55,18 +49,14 @@ export const Footer = () => (
       githubUrl={OPERATE_REPO_URL}
     />
     <RegulatoryNotice>
-      This site has not been reviewed or approved by any competent authority in
-      any Member State of the European Union. Site content is set by the Olas
-      DAO and hosted on its behalf by the site operator — see the{" "}
-      <a
-        href="https://olas.network/disclaimer"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      This site has not been reviewed or approved by any competent authority in any Member State of
+      the European Union. Site content is set by the Olas DAO and hosted on its behalf by the site
+      operator — see the{' '}
+      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
         Disclaimer
       </a>
-      . OLAS is a crypto-asset: its value can go down as well as up and you may
-      lose the entire amount invested.
+      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
+      amount invested.
     </RegulatoryNotice>
   </>
 );

--- a/apps/operate/components/Layout/Footer.tsx
+++ b/apps/operate/components/Layout/Footer.tsx
@@ -1,19 +1,25 @@
-import { Typography } from 'antd';
-import { Fragment } from 'react';
-import styled from 'styled-components';
-import { mainnet } from 'viem/chains';
+import { Typography } from "antd";
+import { Fragment } from "react";
+import styled from "styled-components";
+import { mainnet } from "viem/chains";
 
-import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
-import { EXPLORER_URLS, OPERATE_REPO_URL } from 'libs/util-constants/src';
-import { STAKING_FACTORY, VOTE_WEIGHTING } from 'libs/util-contracts/src/lib/abiAndAddresses';
+import {
+  Footer as CommonFooter,
+  FooterCenterContent,
+} from "libs/ui-components/src";
+import { EXPLORER_URLS, OPERATE_REPO_URL } from "libs/util-constants/src";
+import {
+  STAKING_FACTORY,
+  VOTE_WEIGHTING,
+} from "libs/util-contracts/src/lib/abiAndAddresses";
 
 const contracts = [
   {
-    name: 'VoteWeighting',
+    name: "VoteWeighting",
     link: `${EXPLORER_URLS[mainnet.id]}/address/${VOTE_WEIGHTING.addresses[mainnet.id]}`,
   },
   {
-    name: 'StakingFactory',
+    name: "StakingFactory",
     link: `${EXPLORER_URLS[mainnet.id]}/address/${STAKING_FACTORY.addresses[mainnet.id]}`,
   },
 ];
@@ -23,7 +29,7 @@ const LeftContent = () => (
     {`Contracts: `}
     {contracts.map((item, index) => (
       <Fragment key={index}>
-        {index !== 0 && ' • '}
+        {index !== 0 && " • "}
         <a href={item.link} target="_blank" rel="noopener noreferrer">
           {item.name}
         </a>
@@ -49,14 +55,18 @@ export const Footer = () => (
       githubUrl={OPERATE_REPO_URL}
     />
     <RegulatoryNotice>
-      This site has not been reviewed or approved by any competent authority in any Member State
-      of the European Union. Site content is set by the Olas DAO and hosted on its behalf by the
-      site operator — see the{' '}
-      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+      This site has not been reviewed or approved by any competent authority in
+      any Member State of the European Union. Site content is set by the Olas
+      DAO and hosted on its behalf by the site operator — see the{" "}
+      <a
+        href="https://olas.network/disclaimer"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Disclaimer
       </a>
-      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
-      amount invested.
+      . OLAS is a crypto-asset: its value can go down as well as up and you may
+      lose the entire amount invested.
     </RegulatoryNotice>
   </>
 );

--- a/apps/operate/components/Layout/Footer.tsx
+++ b/apps/operate/components/Layout/Footer.tsx
@@ -1,5 +1,6 @@
 import { Typography } from 'antd';
 import { Fragment } from 'react';
+import styled from 'styled-components';
 import { mainnet } from 'viem/chains';
 
 import { Footer as CommonFooter, FooterCenterContent } from 'libs/ui-components/src';
@@ -31,10 +32,31 @@ const LeftContent = () => (
   </Typography.Text>
 );
 
+const RegulatoryNotice = styled.div`
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 24px 24px;
+  font-size: 12px;
+  color: #949494;
+  text-align: center;
+`;
+
 export const Footer = () => (
-  <CommonFooter
-    leftContent={<LeftContent />}
-    centerContent={<FooterCenterContent />}
-    githubUrl={OPERATE_REPO_URL}
-  />
+  <>
+    <CommonFooter
+      leftContent={<LeftContent />}
+      centerContent={<FooterCenterContent />}
+      githubUrl={OPERATE_REPO_URL}
+    />
+    <RegulatoryNotice>
+      This site has not been reviewed or approved by any competent authority in any Member State
+      of the European Union. Site content is set by the Olas DAO and hosted on its behalf by the
+      site operator — see the{' '}
+      <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+        Disclaimer
+      </a>
+      . OLAS is a crypto-asset: its value can go down as well as up and you may lose the entire
+      amount invested.
+    </RegulatoryNotice>
+  </>
 );

--- a/apps/operate/components/Meta.tsx
+++ b/apps/operate/components/Meta.tsx
@@ -1,10 +1,10 @@
-import Head from "next/head";
-import React from "react";
+import Head from 'next/head';
+import React from 'react';
 
-const SITE_URL = "https://operate.olas.network";
-const SITE_TITLE = "Olas Operate";
+const SITE_URL = 'https://operate.olas.network';
+const SITE_TITLE = 'Olas Operate';
 const SITE_DESCRIPTION =
-  "Become an Operator in the Olas ecosystem. Run AI agents and stake OLAS — staking rewards depend on agent activity and are not guaranteed. Get involved in running decentralized AI-powered systems.";
+  'Become an Operator in the Olas ecosystem. Run AI agents and stake OLAS — staking rewards depend on agent activity and are not guaranteed. Get involved in running decentralized AI-powered systems.';
 const SITE_IMAGE_URL = `${SITE_URL}/images/meta-image.png`;
 
 type MetaProps = {
@@ -22,11 +22,7 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
       {/* <!-- Primary Meta Tags --> */}
       <title>{title}</title>
       <meta name="title" content={title} key="title" />
-      <meta
-        name="description"
-        content={description || SITE_DESCRIPTION}
-        key="description"
-      />
+      <meta name="description" content={description || SITE_DESCRIPTION} key="description" />
 
       {/* <!-- Open Graph / Facebook --> */}
       <meta property="og:type" content="website" key="og:type" />
@@ -40,11 +36,7 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
       <meta property="og:image" content={SITE_IMAGE_URL} key="og:image" />
 
       {/* <!-- Twitter --> */}
-      <meta
-        property="twitter:card"
-        content="summary_large_image"
-        key="twitter:card"
-      />
+      <meta property="twitter:card" content="summary_large_image" key="twitter:card" />
       <meta property="twitter:url" content={url} key="twitter:url" />
       <meta property="twitter:title" content={title} key="twitter:title" />
       <meta
@@ -52,11 +44,7 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
         content={description || SITE_DESCRIPTION}
         key="twitter:description"
       />
-      <meta
-        property="twitter:image"
-        content={SITE_IMAGE_URL}
-        key="twitter:image"
-      />
+      <meta property="twitter:image" content={SITE_IMAGE_URL} key="twitter:image" />
     </Head>
   );
 };

--- a/apps/operate/components/Meta.tsx
+++ b/apps/operate/components/Meta.tsx
@@ -1,10 +1,10 @@
-import Head from 'next/head';
-import React from 'react';
+import Head from "next/head";
+import React from "react";
 
-const SITE_URL = 'https://operate.olas.network';
-const SITE_TITLE = 'Olas Operate';
+const SITE_URL = "https://operate.olas.network";
+const SITE_TITLE = "Olas Operate";
 const SITE_DESCRIPTION =
-  'Become an Operator in the Olas ecosystem. Run AI agents and stake OLAS — staking rewards depend on agent activity and are not guaranteed. Get involved in running decentralized AI-powered systems.';
+  "Become an Operator in the Olas ecosystem. Run AI agents and stake OLAS — staking rewards depend on agent activity and are not guaranteed. Get involved in running decentralized AI-powered systems.";
 const SITE_IMAGE_URL = `${SITE_URL}/images/meta-image.png`;
 
 type MetaProps = {
@@ -22,7 +22,11 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
       {/* <!-- Primary Meta Tags --> */}
       <title>{title}</title>
       <meta name="title" content={title} key="title" />
-      <meta name="description" content={description || SITE_DESCRIPTION} key="description" />
+      <meta
+        name="description"
+        content={description || SITE_DESCRIPTION}
+        key="description"
+      />
 
       {/* <!-- Open Graph / Facebook --> */}
       <meta property="og:type" content="website" key="og:type" />
@@ -36,7 +40,11 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
       <meta property="og:image" content={SITE_IMAGE_URL} key="og:image" />
 
       {/* <!-- Twitter --> */}
-      <meta property="twitter:card" content="summary_large_image" key="twitter:card" />
+      <meta
+        property="twitter:card"
+        content="summary_large_image"
+        key="twitter:card"
+      />
       <meta property="twitter:url" content={url} key="twitter:url" />
       <meta property="twitter:title" content={title} key="twitter:title" />
       <meta
@@ -44,7 +52,11 @@ export const Meta = ({ pageTitle, description, pageUrl }: MetaProps) => {
         content={description || SITE_DESCRIPTION}
         key="twitter:description"
       />
-      <meta property="twitter:image" content={SITE_IMAGE_URL} key="twitter:image" />
+      <meta
+        property="twitter:image"
+        content={SITE_IMAGE_URL}
+        key="twitter:image"
+      />
     </Head>
   );
 };

--- a/apps/operate/components/Meta.tsx
+++ b/apps/operate/components/Meta.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const SITE_URL = 'https://operate.olas.network';
 const SITE_TITLE = 'Olas Operate';
 const SITE_DESCRIPTION =
-  'Become an Operator in the Olas ecosystem using Pearl. Run AI agents, stake assets, and earn rewards while helping to expand the crypto and AI agent network. Get involved in managing decentralized AI-powered systems today!';
+  'Become an Operator in the Olas ecosystem. Run AI agents and stake OLAS — staking rewards depend on agent activity and are not guaranteed. Get involved in running decentralized AI-powered systems.';
 const SITE_IMAGE_URL = `${SITE_URL}/images/meta-image.png`;
 
 type MetaProps = {


### PR DESCRIPTION
Same treatment the bond app received:

- operate.olas.network and build.olas.network meta descriptions reworded to conditional rewards phrasing (rewards depend on agent activity / active developer incentives).
- Site notice added below the footer on both apps, matching the bond app styling and wording.

Strings and two footer additions — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)