### PR TITLE
middleware: hostname-scoped GB restriction for bond, operate, build

### DIFF
--- a/libs/common-middleware/src/lib/prohibitedCountries.ts
+++ b/libs/common-middleware/src/lib/prohibitedCountries.ts
@@ -1,12 +1,25 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import prohibitedCountries from 'libs/util-prohibited-data/src/lib/prohibited-countries.json';
 
-export const getRedirectUrl = async (pathName: string, countryName?: string) => {
+// Apps not available to visitors from these countries due to local marketing
+// restrictions. Scoped by hostname so the other apps sharing this middleware
+// are unaffected.
+const PAGE_RESTRICTED_COUNTRIES = ['GB'];
+const RESTRICTED_HOSTNAMES = ['bond.olas.network', 'operate.olas.network', 'build.olas.network'];
+
+export const getRedirectUrl = async (pathName: string, countryName?: string, hostname?: string) => {
   const prohibitedCountriesCode = Object.values(prohibitedCountries) as unknown as string[];
   const isProhibited = countryName ? prohibitedCountriesCode.includes(countryName) : false;
+  const isPageRestricted = Boolean(
+    countryName &&
+      hostname &&
+      PAGE_RESTRICTED_COUNTRIES.includes(countryName) &&
+      RESTRICTED_HOSTNAMES.includes(hostname),
+  );
+  const isBlocked = isProhibited || isPageRestricted;
 
   if (pathName === '/not-legal') {
-    return isProhibited ? null : '/';
+    return isBlocked ? null : '/';
   }
-  return isProhibited ? '/not-legal' : null;
+  return isBlocked ? '/not-legal' : null;
 };

--- a/libs/common-middleware/src/middleware.ts
+++ b/libs/common-middleware/src/middleware.ts
@@ -15,7 +15,11 @@ export const middleware = async (request: NextRequest) => {
   // this header becomes user-controllable and the geo-block can be bypassed —
   // switch to a proxy-trusted alternative (e.g. CF-IPCountry) at that point.
   const country = request.headers.get('x-vercel-ip-country') ?? undefined;
-  const redirectUrl = await getRedirectUrl(request.nextUrl.pathname, country);
+  const redirectUrl = await getRedirectUrl(
+    request.nextUrl.pathname,
+    country,
+    request.nextUrl.hostname,
+  );
 
   const response = redirectUrl
     ? NextResponse.redirect(new URL(redirectUrl, request.nextUrl))


### PR DESCRIPTION
Extends the shared geo middleware: GB visitors are redirected to /not-legal on bond.olas.network, operate.olas.network and build.olas.network. Scoped by hostname, so govern/contribute/launch/marketplace and other apps sharing libs/common-middleware are unaffected. The hostname parameter is optional and backward-compatible; the existing prohibited-countries behaviour is unchanged.

Companion to olas-website#538 (same restriction for the token/bond/staking/operate/build pages there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)