### PR TITLE
bond/operate/build: add missing not-legal pages

### DIFF
--- a/apps/bond/pages/not-legal.jsx
+++ b/apps/bond/pages/not-legal.jsx
@@ -11,7 +11,18 @@ const NotLegal = () => (
     <Result
       status="warning"
       title="Access restricted"
-      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+      subTitle={
+        <>
+          Due to applicable legal and regulatory requirements, access to this site is not available
+          from your current region. We use your approximate location data (region-level IP
+          information) solely for the purpose of enforcing this restriction and do not store this
+          information. For more details, please refer to our{' '}
+          <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+          .
+        </>
+      }
     />
   </NotLegalContainer>
 );

--- a/apps/bond/pages/not-legal.jsx
+++ b/apps/bond/pages/not-legal.jsx
@@ -1,0 +1,19 @@
+import { Result } from 'antd';
+import styled from 'styled-components';
+
+const NotLegalContainer = styled.div`
+  position: relative;
+  top: 100px;
+`;
+
+const NotLegal = () => (
+  <NotLegalContainer>
+    <Result
+      status="warning"
+      title="Access restricted"
+      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+    />
+  </NotLegalContainer>
+);
+
+export default NotLegal;

--- a/apps/build/pages/not-legal.tsx
+++ b/apps/build/pages/not-legal.tsx
@@ -11,7 +11,18 @@ const NotLegal = () => (
     <Result
       status="warning"
       title="Access restricted"
-      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+      subTitle={
+        <>
+          Due to applicable legal and regulatory requirements, access to this site is not available
+          from your current region. We use your approximate location data (region-level IP
+          information) solely for the purpose of enforcing this restriction and do not store this
+          information. For more details, please refer to our{' '}
+          <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+          .
+        </>
+      }
     />
   </NotLegalContainer>
 );

--- a/apps/build/pages/not-legal.tsx
+++ b/apps/build/pages/not-legal.tsx
@@ -1,0 +1,19 @@
+import { Result } from 'antd';
+import styled from 'styled-components';
+
+const NotLegalContainer = styled.div`
+  position: relative;
+  top: 100px;
+`;
+
+const NotLegal = () => (
+  <NotLegalContainer>
+    <Result
+      status="warning"
+      title="Access restricted"
+      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+    />
+  </NotLegalContainer>
+);
+
+export default NotLegal;

--- a/apps/operate/pages/not-legal.tsx
+++ b/apps/operate/pages/not-legal.tsx
@@ -11,7 +11,18 @@ const NotLegal = () => (
     <Result
       status="warning"
       title="Access restricted"
-      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+      subTitle={
+        <>
+          Due to applicable legal and regulatory requirements, access to this site is not available
+          from your current region. We use your approximate location data (region-level IP
+          information) solely for the purpose of enforcing this restriction and do not store this
+          information. For more details, please refer to our{' '}
+          <a href="https://olas.network/disclaimer" target="_blank" rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+          .
+        </>
+      }
     />
   </NotLegalContainer>
 );

--- a/apps/operate/pages/not-legal.tsx
+++ b/apps/operate/pages/not-legal.tsx
@@ -1,0 +1,19 @@
+import { Result } from 'antd';
+import styled from 'styled-components';
+
+const NotLegalContainer = styled.div`
+  position: relative;
+  top: 100px;
+`;
+
+const NotLegal = () => (
+  <NotLegalContainer>
+    <Result
+      status="warning"
+      title="Access restricted"
+      subTitle="Due to applicable legal and regulatory requirements, access to this site is not available from your current region."
+    />
+  </NotLegalContainer>
+);
+
+export default NotLegal;


### PR DESCRIPTION
The shared middleware redirects restricted regions to /not-legal, but none of bond/operate/build actually had that page — redirected visitors landed on a 404 (verified live: all three return 404 on /not-legal). This adds the page to each app, following the marketplace app's existing pattern, with generalized wording (the route now serves both the sanctions list and the GB restriction).

Side effect that matters: touching apps/bond, apps/operate and apps/build forces Vercel to redeploy all three — #436 changed only libs/, and bond's deploy appears to have been skipped by the ignored-build-step, which would explain why the GB redirect works on operate/build but not on bond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)