### PR TITLE
bond: enforce geo restriction on the root page server-side

### DIFF
--- a/apps/bond/pages/index.jsx
+++ b/apps/bond/pages/index.jsx
@@ -1,11 +1,28 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getRedirectUrl } from 'libs/common-middleware/src/lib/prohibitedCountries';
+
 import { HomePage } from 'components/Home';
 import { Meta } from 'components/Meta';
 
 const Index = () => (
   <>
-    <Meta description="Get access to discounted OLAS by bonding capital into the Olas protocol. Explore bonding products and manage your bonds." />
+    <Meta description="Bond capital into the Olas protocol and receive OLAS at the quoted bond price after a vesting period. Explore bonding products and manage your bonds." />
     <HomePage />
   </>
 );
+
+// The edge proxy does not run for the root path on this setup (the locale
+// rewrite serves it from the filesystem first), so the same geo restriction
+// is enforced server-side here.
+export const getServerSideProps = async ({ req }) => {
+  const countryHeader = req.headers['x-vercel-ip-country'];
+  const country = Array.isArray(countryHeader) ? countryHeader[0] : countryHeader;
+  const redirectUrl = await getRedirectUrl('/', country, req.headers.host);
+
+  if (redirectUrl) {
+    return { redirect: { destination: redirectUrl, permanent: false } };
+  }
+  return { props: {} };
+};
 
 export default Index;


### PR DESCRIPTION
Fixes the escape reported in review: on bond.olas.network the subpages redirect restricted regions correctly but the root does not. Diagnosis: the edge proxy is not invoked for the root path on this setup — the locale rewrite serves / from the filesystem first (observable via x-matched-path: /en with no proxy headers). Subpages hit the proxy normally. operate and build mask the same root escape because their roots app-redirect to subpages that are covered.

Fix: bond's index page now runs the same getRedirectUrl logic in getServerSideProps, so the root is enforced server-side regardless of proxy behaviour. Bonus: this page's own meta description override still carried the old promotional wording (it bypassed the #434 site-default fix) — aligned with the neutral phrasing.

Verified logic against live behaviour from a GB egress: subpage 307 → /not-legal, /not-legal 200 (correct hold), root previously 200 (escape) — this PR closes the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)