### PR TITLE
ci(snyk): tag CLI scans with public repo URL so they use the open-source quota

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -73,7 +73,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           # Redirect both stdout and stderr to prevent error contamination
-          snyk code test --org=00508cff-0e2b-4bb5-aaf0-9fa7cc430473 --sarif > snyk-code.sarif 2>&1 || true
+          snyk code test --org=00508cff-0e2b-4bb5-aaf0-9fa7cc430473 --remote-repo-url=https://github.com/${{ github.repository }} --sarif > snyk-code.sarif 2>&1 || true
           echo "✅ Snyk Code test completed."
         continue-on-error: true
 
@@ -83,7 +83,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           # Monitor only the root package.json to avoid duplicate scans in a monorepo
-          snyk monitor --org=00508cff-0e2b-4bb5-aaf0-9fa7cc430473 --file=package.json --project-name="autonolas-frontend-mono" || true
+          snyk monitor --org=00508cff-0e2b-4bb5-aaf0-9fa7cc430473 --file=package.json --project-name="autonolas-frontend-mono" --remote-repo-url=https://github.com/${{ github.repository }} || true
         continue-on-error: true
 
       # Show any Snyk CLI errors for easier debugging


### PR DESCRIPTION
## What

Add `--remote-repo-url=https://github.com/${{ github.repository }}` to both the `snyk code test` and `snyk monitor` commands in `.github/workflows/snyk-security.yml`.

## Why

Snyk CLI scans without `--remote-repo-url` can't read the repository's GitHub visibility, so they **default to counting against the private test quota** — even though this repo is public. On the Snyk Free plan that burns the limited private-manifest and Snyk Code allowances instead of the **unlimited open-source** buckets these public-repo scans are entitled to.

Passing the repo URL tells the CLI which public repo it's scanning, so future runs are classified as open-source and stop consuming quota. `${{ github.repository }}` resolves to `owner/repo` automatically.

The flag is supported by both `snyk code test` and `snyk monitor` per the [Snyk CLI docs](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/commands/code-test); no behavioural change beyond classification.

Part of an org-wide fix across all repos running the shared `snyk-security.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)