### PR TITLE
fix: [BDMARK-2237] clear brace-expansion and postcss high-severity advisories

### DIFF
--- a/.supply-chain/audit-allowlist.json
+++ b/.supply-chain/audit-allowlist.json
@@ -27,6 +27,15 @@
       "reason": "Same GHSA on the js-yaml 3.x line, reached via nx build-time tooling (@nx/next > nx > @yarnpkg/parsers > js-yaml 3.x). Build-time only, trusted input, not in the shipped runtime. Cannot be co-resolved with the 4.x consumer via a single Yarn resolution without breaking API compatibility.",
       "added": "2026-07-23",
       "review": "2026-10-23"
+    },
+    {
+      "id": 1124334,
+      "ghsa": "GHSA-mh99-v99m-4gvg",
+      "package": "brace-expansion",
+      "severity": "high",
+      "reason": "DoS (unbounded expansion length -> OOM crash) on crafted glob patterns. All 10 paths reach it through minimatch in build-time tooling only (@nx/next > @nx/js > minimatch; @nx/devkit > ejs > jake > minimatch; tailwindcss > sucrase > glob > minimatch; expo-constants > @expo/fingerprint > minimatch) — the patterns are our own config globs, never untrusted input, and none of this is in the shipped Next.js runtime bundle. The fix is only on the 5.x line (>=5.0.8); the maintenance-v2 line tops out at 2.1.4, still inside the advisory range. Resolving to 5.0.9 was tested and breaks the build with 'expand is not a function' — brace-expansion 5.x's CJS export is not a drop-in for the 2.x default export that minimatch 5.x calls. Revisit when minimatch ships a release depending on brace-expansion >=5.0.8.",
+      "added": "2026-07-31",
+      "review": "2026-10-31"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "micromatch": "4.0.8",
     "min-document": "2.19.1",
     "nanoid": "3.3.11",
-    "postcss": "8.5.12",
+    "postcss": "8.5.25",
     "qs": "6.14.2",
     "send": "0.19.0",
     "serve-static": "1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15936,7 +15936,7 @@ nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
-nanoid@3.3.11, nanoid@^3.0.2, nanoid@^3.1.20, nanoid@^3.1.23, nanoid@^3.3.11:
+nanoid@3.3.11, nanoid@^3.0.2, nanoid@^3.1.20, nanoid@^3.1.23, nanoid@^3.3.16:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -16960,12 +16960,12 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.5.12, postcss@^8.4.47:
-  version "8.5.12"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
-  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
+postcss@8.4.31, postcss@8.5.25, postcss@^8.4.47:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Why

Two new HIGH advisories are failing the `yarn audit (production deps)` gate on `main`, blocking every open PR.

## postcss — fixed by bump

**GHSA-r28c-9q8g-f849** — path traversal in previous-source-map auto-loading (`sourceMappingURL`) leading to arbitrary `.map` file disclosure.

Bumped the **existing** resolution `8.5.12` → `8.5.25`. Same minor line, no API change. Reached via `next > postcss` and `@binance/w3w-* > tailwindcss > postcss`.

## brace-expansion — allowlisted, with a tested reason

**GHSA-mh99-v99m-4gvg** — DoS via unbounded expansion length causing an OOM crash.

I tried the resolution first. It does not work:

- The fix exists **only on the 5.x line** (`>=5.0.8`). The `maintenance-v2` line tops out at `2.1.4`, still inside the advisory range — so there is no in-major upgrade path.
- Resolving to `5.0.9` **breaks the build**: `NX  expand is not a function`. brace-expansion 5.x's CJS export is not a drop-in for the 2.x default export that `minimatch` 5.x calls.

So it is allowlisted with a review date of 2026-10-31, on the same reachability argument as the two existing `js-yaml` entries. All 10 paths sit behind `minimatch` in build-time tooling:

```
@nx/next > @nx/js > minimatch > brace-expansion
@nx/next > @nx/devkit > ejs > jake > minimatch > brace-expansion
@binance/... > tailwindcss > sucrase > glob > minimatch > brace-expansion
@solana/... > expo-constants > @expo/fingerprint > minimatch > brace-expansion
```

Those globs are our own config patterns, never untrusted input, and none of this is in the shipped Next.js runtime bundle. Revisit when `minimatch` ships a release depending on `brace-expansion >=5.0.8`.

## Verification

- [x] `yarn audit:prod` — OK (3 allowlisted, no unlisted high/critical)
- [x] `yarn lint:lockfile` — no issues
- [x] `yarn audit:install-hooks` — OK (8 allowlisted); regenerated allowlist is byte-identical, so no new install hooks
- [x] `nx run marketplace:build` — succeeds on postcss 8.5.25 (this is what caught the brace-expansion break)

CI will exercise the remaining app builds.

## Note

This unblocks #441, which is currently red only on this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)